### PR TITLE
Bump from psycopg2 to psycopg3.

### DIFF
--- a/action/recommendation/index_picker.py
+++ b/action/recommendation/index_picker.py
@@ -2,7 +2,7 @@ import datetime
 import math
 import random
 
-import psycopg2
+import psycopg
 from plumbum import cli, local
 
 NOOP_ACTION = "SELECT 1;"
@@ -80,7 +80,7 @@ class IndexPickerCLI(cli.Application):
 
         # Loop through all of the action batches, applying recommended
         # actions as long as there is an improvement in overall returns.
-        with psycopg2.connect(db_conn_string) as conn:
+        with psycopg.connect(db_conn_string) as conn:
             with conn.cursor() as cursor:
                 for batch in action_batches():
                     batch = list(batch)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ doit
 flake8
 isort
 plumbum
-psycopg2
+psycopg
 toml


### PR DESCRIPTION
psycopg3 was released on 2021-10-13. It seems to be mostly quality of life changes and one important change around the `Connection` object. To quote the psycopg docs:

> When the block is exited, if there is a transaction open, it will be committed. If an exception is raised within the block the transaction is rolled back. In both cases the connection is closed. It is roughly the equivalent of:
>
> ```
> conn = psycopg.connect()
> try:
>     ... # use the connection
> except BaseException:
>     conn.rollback()
> else:
>     conn.commit()
> finally:
>     conn.close()
> ```
>
> This behaviour is not what psycopg2 does: in psycopg2 there is no final close() and the connection can be used in several with statements to manage different transactions. This behaviour has been considered non-standard and surprising so it has been replaced by the more explicit transaction() block.

- Release notes: https://www.psycopg.org/articles/2021/10/13/psycopg-30-released/
- Some comparison to psycopg2: https://www.psycopg.org/psycopg3/docs/basic/usage.html