### PR TITLE
Add the Pilot component.

### DIFF
--- a/bootstrap.sql
+++ b/bootstrap.sql
@@ -1,0 +1,19 @@
+-- This SQL file sets up databases and users across the different components.
+
+-- Pilot.
+DROP DATABASE IF EXISTS np_pilot;
+DROP USER IF EXISTS np_pilot_daemon;
+DROP USER IF EXISTS np_pilot_client;
+
+CREATE DATABASE np_pilot;
+CREATE USER np_pilot_daemon WITH ENCRYPTED PASSWORD 'np_pilot_daemon_pass';
+GRANT ALL PRIVILEGES ON DATABASE np_pilot TO np_pilot_daemon;
+CREATE USER np_pilot_client WITH ENCRYPTED PASSWORD 'np_pilot_client_pass';
+GRANT ALL PRIVILEGES ON DATABASE np_pilot TO np_pilot_client;
+
+-- Action selection: OpenSpiel.
+DROP DATABASE IF EXISTS np_as_spiel;
+DROP USER IF EXISTS np_as_spiel_user;
+CREATE DATABASE np_as_spiel;
+CREATE USER np_as_spiel_user WITH ENCRYPTED PASSWORD 'np_as_spiel_user_pass';
+GRANT ALL PRIVILEGES ON DATABASE np_as_spiel to np_as_spiel_user;

--- a/pilot/bootstrap_tables.sql
+++ b/pilot/bootstrap_tables.sql
@@ -1,0 +1,60 @@
+-- This sets up the tables for the Pilot component.
+DROP TABLE IF EXISTS pilot_results;
+DROP TABLE IF EXISTS pilot_commands;
+DROP TYPE IF EXISTS pilot_cmd_type;
+DROP TYPE IF EXISTS pilot_cmd_status;
+
+-- INPUT TABLE: pilot_commands.
+-- The Pilot client inserts rows into this table to send commands.
+CREATE TYPE pilot_cmd_type AS ENUM ('cmd_run', 'cmd_abort');
+CREATE TABLE IF NOT EXISTS pilot_commands
+(
+    id    SERIAL PRIMARY KEY,
+    ts    TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    ctype pilot_cmd_type,
+    args  TEXT
+);
+
+-- OUTPUT TABLE: pilot_results.
+-- The Pilot daemon writes results of completed commands into this table.
+CREATE TYPE pilot_cmd_status AS ENUM ('running', 'success', 'aborted');
+CREATE TABLE IF NOT EXISTS pilot_results
+(
+    id     SERIAL PRIMARY KEY,
+    ts     TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    status pilot_cmd_status,
+    cid    INT REFERENCES pilot_commands (id),
+    output TEXT
+);
+
+-- notify_pilot() is a trigger that should be invoked
+-- to notify the pilot daemon (Python) of new commands
+-- that should be performed.
+CREATE OR REPLACE FUNCTION pilot_notify() RETURNS TRIGGER AS
+$$
+BEGIN
+    -- NEW = new database row for INSERT in row trigger.
+    -- For more info, see: https://www.postgresql.org/docs/14/plpgsql-trigger.html
+    PERFORM pg_notify(
+            'pilot',
+            NEW.id::text || ',' || NEW.ctype::text || ',' || NEW.args::text
+        );
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Register the pilot_notify() trigger to be run every time a row is
+-- inserted into pilot_commands.
+CREATE
+OR
+REPLACE
+TRIGGER cmd_notify AFTER
+INSERT
+ON pilot_commands FOR EACH ROW
+EXECUTE PROCEDURE pilot_notify();
+
+-- TODO(WAN): hardcoded np_pilot_client user.
+-- Grant permissions.
+GRANT USAGE, SELECT ON SEQUENCE pilot_commands_id_seq TO np_pilot_client;
+GRANT INSERT ON pilot_commands TO np_pilot_client;
+GRANT SELECT ON pilot_results TO np_pilot_client;

--- a/pilot/client.py
+++ b/pilot/client.py
@@ -1,0 +1,47 @@
+import csv
+from io import StringIO
+
+from plumbum import cli
+from protocol import Client
+
+
+class ClientCLI(cli.Application):
+    db_conn_string = cli.SwitchAttr(
+        "--db-conn-string",
+        str,
+        mandatory=True,
+        help="Connection string to Pilot database.",
+    )
+    command = cli.SwitchAttr(
+        "--command",
+        str,
+        mandatory=True,
+        help="The Pilot Daemon command to be invoked.",
+    )
+
+    def main(self, *args):
+        # Get the function to be invoked that will
+        # send a command to the Pilot Daemon.
+        client = Client(self.db_conn_string)
+        func = client.get_function(self.command)
+
+        # Get the arguments to the function, if any.
+        data = {}
+        assert len(args) in [0, 1]
+        if len(args) == 1:
+            # TODO(WAN): We assume a CSV string of input.
+            iostr = StringIO(args[0])
+            reader = csv.reader(iostr)
+            data = {
+                key: val
+                for row in reader
+                for item in row
+                for key, val in [item.split("=", maxsplit=1)]
+            }
+
+        # Invoke the function.
+        func(data)
+
+
+if __name__ == "__main__":
+    ClientCLI.run()

--- a/pilot/daemon.py
+++ b/pilot/daemon.py
@@ -1,0 +1,59 @@
+# This file defines the Pilot daemon.
+# The Pilot daemon handles logic for controlling the explorer, etc.
+#
+# Before modifying this file, please read:
+# https://www.postgresql.org/docs/14/sql-notify.html
+# https://www.postgresql.org/docs/14/sql-listen.html
+# https://www.psycopg.org/psycopg3/docs/advanced/async.html#async-notify
+
+
+import select
+
+import protocol
+import psycopg
+from plumbum import cli
+
+
+def _handle(event):
+    """
+    Handle the NOTIFY event.
+
+    Parameters
+    ----------
+    event : protocol.NotifyEvent
+        The event to be handled.
+    """
+    print(event)
+    pass
+
+
+class DaemonCLI(cli.Application):
+    db_conn_string = cli.SwitchAttr("--db-conn-string", str, mandatory=True)
+    channel_name = cli.SwitchAttr("--channel-name", str, default="pilot")
+    timeout_sec = cli.SwitchAttr("--timeout-sec", int, default=60)
+
+    def main(self):
+        # autocommit is required because of how NOTIFY interacts with SQL transactions.
+        with psycopg.connect(self.db_conn_string, autocommit=True) as conn:
+            cursor = conn.cursor(row_factory=psycopg.rows.dict_row)
+            cursor.execute(f"LISTEN {self.channel_name};")
+            print(f"Listening (timeout {self.timeout_sec} s): {self.channel_name}")
+
+            while True:
+                # Wait for a NOTIFY message to be received.
+                if select.select([conn], [], [], self.timeout_sec) == ([], [], []):
+                    # A NOTIFY message was not received and we timed out.
+                    # TODO(WAN): Is there any use case for the Explorer timing out?
+                    #  e.g., non-critical maintenance tasks to be run.
+                    pass
+                else:
+                    # NOTIFY was received. Process all the NOTIFY messages.
+                    # psycopg's add_notify_handler is NOT used because the handler
+                    # only fires during a connection operation.
+                    for notify in conn.notifies():
+                        event = protocol.Server.notify_recv(notify)
+                        _handle(event)
+
+
+if __name__ == "__main__":
+    DaemonCLI.run()

--- a/pilot/protocol.py
+++ b/pilot/protocol.py
@@ -1,0 +1,127 @@
+# This file defines the protocol for messages sent over LISTEN/NOTIFY.
+# The constants in this file must be kept in sync with bootstrap_tables.sql.
+
+# Before modifying this file, please read:
+# - https://www.psycopg.org/psycopg3/docs/basic/params.html
+
+import enum
+import json
+from dataclasses import dataclass
+from typing import Dict
+
+import psycopg
+
+
+class CmdType(enum.Enum):
+    """
+    The possible types of commands.
+    This must be kept in sync with pilot_cmd_type.
+    """
+
+    RUN = "cmd_run"
+    ABORT = "cmd_abort"
+
+
+@dataclass
+class NotifyEvent:
+    """
+    A parsed NOTIFY event.
+    """
+
+    pid: int  # The server process PID of the NOTIFY session.
+    channel: str  # The channel which the notify came on.
+    cmd_id: str  # The command ID.
+    cmd_type: CmdType  # The command type.
+    args: Dict  # Any additional data sent in the notify.
+
+
+class Server:
+    """
+    Wrapper for server methods for the Pilot component.
+    """
+
+    @staticmethod
+    def notify_recv(notify):
+        """
+        Parse the raw NOTIFY event received by psycopg.
+
+        Parameters
+        ----------
+        notify : psycopg.Notify
+            The notification received by psycopg.
+
+        Returns
+        -------
+        event : NotifyEvent
+            The notify event that was received.
+        """
+        cmd_id, cmd_type, args_str = notify.payload.split(",", maxsplit=2)
+        event = NotifyEvent(
+            notify.pid,
+            notify.channel,
+            cmd_id,
+            CmdType(cmd_type),
+            json.loads(args_str),
+        )
+        return event
+
+
+class Client:
+    """
+    Wrapper for Client methods for the Pilot component.
+    """
+
+    def __init__(self, db_conn_string):
+        """
+        Create a new Client instance.
+
+        Parameters
+        ----------
+        db_conn_string : str
+            Connection string to the Pilot database.
+        """
+        self.db_conn_string = db_conn_string
+
+    def _notify_send(self, ctype, **kwargs):
+        """
+        Send a notify from the client to the Pilot.
+
+        Parameters
+        ----------
+        ctype : CmdType
+            Any command recognized by the Pilot.
+        kwargs : str
+            Any number of keyword arguments to the specified command.
+        """
+        with psycopg.connect(self.db_conn_string) as conn:
+            with conn.cursor() as cursor:
+                sql = (
+                    "INSERT INTO "
+                    "pilot_commands (ctype, args)"
+                    "VALUES "
+                    "(%(ctype)s, %(args)s)"
+                )
+                params = {"ctype": ctype.value, "args": json.dumps(kwargs)}
+                cursor.execute(sql, params)
+
+    def get_function(self, cli_arg):
+        """
+        Get the specified convenience function,
+        or construct one on the fly.
+
+        Parameters
+        ----------
+        cli_arg : str
+            The name of a convenience function,
+            or the name of the NOTIFY event to invoke.
+
+        Returns
+        -------
+        func : Callable[Dict, None]
+            The convenience function to be invoked with a dict of arguments.
+        """
+        # TODO(WAN): Complicated NOTIFY chains can go here.
+        def new_func(args):
+            self._notify_send(CmdType.RUN, command=cli_arg, **args)
+
+        return new_func


### PR DESCRIPTION
Add the Pilot component.

New tasks:
- bootstrap: Bootstrap Pilot and OpenSpiel databases, users.
- pilot_bootstrap: Bootstrap pilot tables, handle role grants.
- pilot_daemon: Run Pilot Daemon aka server.
- pilot_client: Run Pilot client, i.e., send a command to the Pilot Daemon.

---

This is only the Pilot component; the Explorer doesn't exist yet.
I figured I would break the PRs up a little more since it was getting long.

Sample usage:
(server)
```bash
doit pilot_daemon
# Currently, this does not actually run the daemon,
# it gives you the bash command to copypaste to run.
# This is because the Daemon is long-running and locks .doit.db.
```

(client)
```bash
doit pilot_client --command=explorearun --args="foo=bar"
```