### PR TITLE
Send TScout output to stdout and stderr during data generation.

### DIFF
--- a/behavior/datagen/gen.py
+++ b/behavior/datagen/gen.py
@@ -383,7 +383,9 @@ class DataGeneratorCLI(cli.Application):
             logger.debug("Attaching TScout.")
             old_wd = os.getcwd()
             os.chdir(self.dir_tscout)
-            cmd.sudo["python3"]["tscout.py", postmaster_pid, "--outdir", dir_tscout_output].run_bg()
+            cmd.sudo["python3"]["tscout.py", postmaster_pid, "--outdir", dir_tscout_output].run_bg(
+                stdout=sys.stdout, stderr=sys.stderr
+            )
             os.chdir(old_wd)
         except (FileNotFoundError, ProcessExecutionError) as err:
             self.clean(err, terminate=True, message="Error initializing TScout.")


### PR DESCRIPTION
This PR changes `run_bg` arguments for TScout such that TScout's logging messages appear in the console.  This enables seeing when TScout fails to attach properly and the TScout Collector's number of dropped events.  The number of dropped events is essential information, as it explains significant differences in datasets.  For example, TPC-C data generation runs have been observed as losing 80 events in the "training" run and 210 events in the "evaluation" run, leading to zero evaluation data for the NestLoop operator.  It is likely worth logging this data to file, but this is deferred to a future PR.

---

This PR enables us to see how many TScout events were lost.  #15 