### PR TITLE
Add Docker Functionality

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,6 +6,7 @@
 # Build artifacts.
 artifacts/
 
+
 # Directory for building code.
 build/
 
@@ -19,7 +20,8 @@ docs/
 cmake-build-*/
 
 # Ignore Python bytecode cache files.
-__pycache__/
+**/__pycache__
+**/*.pyc
 
 # Ignore Python doit db.
 .doit.db

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,26 @@
+# NoisePage-Pilot Docker ignores
+.git
+.gitignore
+
+# By convention, we ignore the following folders.
+# Build artifacts.
+artifacts/
+
+# Directory for building code.
+build/
+
+# Docker containers don't need documentation
+docs/
+
+# Ignore most JetBrains IDE files.
+.idea/
+
+# Ignore temporary CLion CMake directories.
+cmake-build-*/
+
+# Ignore Python bytecode cache files.
+__pycache__/
+
+# Ignore Python doit db.
+.doit.db
+.doit.db.*

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,4 @@
-# NoisePage-Pilot Docker ignores
+# NoisePage-Pilot Docker ignores.
 .git
 .gitignore
 
@@ -10,7 +10,7 @@ artifacts/
 # Directory for building code.
 build/
 
-# Docker containers don't need documentation
+# Docker containers don't need documentation.
 docs/
 
 # Ignore most JetBrains IDE files.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,7 +35,7 @@ RUN set -eux; \
     linux-headers-$(uname -r) \
     && rm -rf /var/lib/apt/lists/*
 
-# TScout also requires psutil (on the root user)
+# TScout also requires psutil (on the root user).
 RUN python3 -m pip install --upgrade psutil
 
 RUN useradd --create-home --shell /bin/bash --home-dir /home/terrier \
@@ -45,7 +45,7 @@ USER terrier
 ENV HOME=/home/terrier
 WORKDIR $HOME
 
-# Add pip package installation directory to PATH
+# Add pip package installation directory to PATH.
 ENV PATH="${HOME}/.local/bin/:${PATH}"
 
 # Copy the contents of the build context (working directory).

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,72 @@
+# syntax=docker/dockerfile:1
+# NoisePage officially supports Ubuntu 20.04.
+FROM ubuntu:20.04
+
+USER root
+
+# Suppress interactive dialog.
+ARG DEBIAN_FRONTEND=noninteractive
+
+# NoisePage Pilot requirements.
+RUN set -eux; \
+    apt-get update \
+    && apt-get install -y \
+    # Behavior modeling requirements.
+    sudo \
+    git \
+    python3 \
+    python3-pip \
+    python3.8-venv \
+    graphviz \ 
+    # Postgres requirements.
+    bison \
+    build-essential \
+    flex \
+    libreadline-dev \
+    libssl-dev \
+    libxml2-dev \
+    libxml2-utils \
+    libxslt-dev \
+    xsltproc \
+    zlib1g-dev \
+    # BenchBase requirements.
+    openjdk-17-jdk \
+    unzip \
+    # TScout (BCC) requirements.
+    bpfcc-tools \
+    linux-headers-$(uname -r) \
+    && rm -rf /var/lib/apt/lists/*
+
+# TScout also requires psutil (on the root user)
+RUN python3 -m pip install --upgrade psutil
+
+# Enable users to run sudo without entering password
+RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+# Create a non-sudo user and switch to them.
+# This is because PostgreSQL binaries don't like being
+# run as root, e.g., initdb.
+RUN useradd --create-home --shell /bin/bash --home-dir /home/terrier --password "$(openssl passwd -1 terrier)" -G sudo terrier 
+USER terrier
+ENV HOME=/home/terrier
+WORKDIR $HOME
+
+# Add pip package installation directory to PATH
+ENV PATH="${HOME}/.local/bin/:${PATH}"
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+# Copy the contents of the build context (working directory).
+COPY --chown=terrier:terrier . ${HOME}/noisepage-pilot
+
+# Set the pilot directory to current working directory.
+WORKDIR ${HOME}/noisepage-pilot
+
+# Install required Python packages.
+RUN python3 -m pip install --user --upgrade -r requirements.txt
+
+# Build the pilot.
+RUN doit noisepage_build benchbase_build
+
+# Provide shell entrypoint.
+ENTRYPOINT /bin/bash

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,8 +2,6 @@
 # NoisePage officially supports Ubuntu 20.04.
 FROM ubuntu:20.04
 
-USER root
-
 # Suppress interactive dialog.
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -40,21 +38,15 @@ RUN set -eux; \
 # TScout also requires psutil (on the root user)
 RUN python3 -m pip install --upgrade psutil
 
-# Enable users to run sudo without entering password
-RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
-
-# Create a non-sudo user and switch to them.
-# This is because PostgreSQL binaries don't like being
-# run as root, e.g., initdb.
-RUN useradd --create-home --shell /bin/bash --home-dir /home/terrier --password "$(openssl passwd -1 terrier)" -G sudo terrier 
+RUN useradd --create-home --shell /bin/bash --home-dir /home/terrier \
+    --password "$(openssl passwd -1 terrier)" -G sudo terrier  \
+    && echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 USER terrier
 ENV HOME=/home/terrier
 WORKDIR $HOME
 
 # Add pip package installation directory to PATH
 ENV PATH="${HOME}/.local/bin/:${PATH}"
-
-ARG DEBIAN_FRONTEND=noninteractive
 
 # Copy the contents of the build context (working directory).
 COPY --chown=terrier:terrier . ${HOME}/noisepage-pilot

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,26 @@
+# NoisePage-Pilot Docker Information
+
+The `docker` folder is for all files that relate to development or CI docker images and containers.
+
+## Tips
+
+- Run the below commands from the project root.
+- You must rebuild the Docker image every time there are changes in your source tree.
+
+## Helpful Commands
+
+To build a local development image you can use:
+
+```docker build -f ./docker/Dockerfile --tag noisepage-pilot_dev .```
+
+To build a container using the current `main` branch reference on GitHub, you can use:
+
+```docker build -f ./docker/Dockerfile --tag noisepage-pilot_main https://github.com/cmu-db/noisepage-pilot.git#main```
+
+To run the Docker container you can use:
+
+```docker run -it --rm --privileged --cap-add="ALL" noisepage-pilot_dev```
+
+To delete old images, you can use:
+
+```docker system prune --all```

--- a/docker/README.md
+++ b/docker/README.md
@@ -9,7 +9,7 @@ A successful build-and-run will put you in the shell in the running container.  
 - Run the below commands from the project root.
 - You must rebuild the Docker image every time there are changes in your source tree.
 
-## Helpful Commands
+## Helpful commands
 
 To build a local development image you can use:
 
@@ -26,3 +26,7 @@ To run the Docker container you can use:
 To delete old images, you can use:
 
 ```docker system prune --all```
+
+## Docker gotchas
+
+Anything that takes you over 1 day to figure out should be documented here.

--- a/docker/README.md
+++ b/docker/README.md
@@ -2,6 +2,8 @@
 
 The `docker` folder is for all files that relate to development or CI docker images and containers.
 
+A successful build-and-run will put you in the shell in the running container.  At this point, you should be able to run `doit` tasks or perform other general development tasks.
+
 ## Tips
 
 - Run the below commands from the project root.
@@ -19,7 +21,7 @@ To build a container using the current `main` branch reference on GitHub, you ca
 
 To run the Docker container you can use:
 
-```docker run -it --rm --privileged --cap-add="ALL" noisepage-pilot_dev```
+```docker run -it --rm --cap-add="ALL" noisepage-pilot_dev```
 
 To delete old images, you can use:
 


### PR DESCRIPTION
This PR adds basic Docker functionality for the pilot.  The README explains basic usage and other relevant information.  In essence, all you need to do is run (from the project root): 

```
docker build -f ./docker/Dockerfile --tag noisepage-pilot_dev .
docker run -it --rm --cap-add="ALL" noisepage-pilot_dev
```

This should pop you into a shell in the container, ready to run `doit` tasks.  I've found this generally helpful for testing code without affecting my overall development environment.