### PR TITLE
Add filtered tables for TPC-C create index actions.

### DIFF
--- a/action/generation/generate_create_index_tpcc.py
+++ b/action/generation/generate_create_index_tpcc.py
@@ -115,22 +115,67 @@ tables = {
     ],
 }
 
+tables_filtered = {
+    "warehouse": [
+        "w_id",
+    ],
+    "item": [
+        "i_id",
+    ],
+    "stock": [
+        "s_w_id",
+        "s_i_id",
+        "s_quantity",
+    ],
+    "district": [
+        "d_w_id",
+        "d_id",
+    ],
+    "customer": [
+        "c_w_id",
+        "c_d_id",
+        "c_id",
+        "c_last",
+        "c_first",
+    ],
+    "oorder": [
+        "o_w_id",
+        "o_d_id",
+        "o_id",
+        "o_c_id",
+    ],
+    "new_order": [
+        "no_w_id",
+        "no_d_id",
+        "no_o_id",
+    ],
+    "order_line": [
+        "ol_w_id",
+        "ol_d_id",
+        "ol_o_id",
+        "ol_i_id",
+    ],
+}
+
 
 class GenerateCreateIndexTPCC(cli.Application):
     min_num_cols = cli.SwitchAttr("--min-num-cols", int, mandatory=True)
     max_num_cols = cli.SwitchAttr("--max-num-cols", int, mandatory=True)
     output_sql = cli.SwitchAttr("--output-sql", str, mandatory=True)
+    filter_tables = cli.Flag("--filter-tables", default=False)
 
     def main(self):
         assert 1 <= self.min_num_cols, "Need at least one column."
         assert self.min_num_cols <= self.max_num_cols, "min must be <= max."
+
+        tables_used = tables_filtered if self.filter_tables else tables
 
         for max_n_cols in range(self.max_num_cols + 1):
             with open(self.output_sql, "w") as f:
                 permutations = (
                     (table, permutation)
                     for num_cols in range(self.min_num_cols, max_n_cols + 1)
-                    for table, cols in tables.items()
+                    for table, cols in tables_used.items()
                     for permutation in itertools.permutations(cols, num_cols)
                 )
                 for table, permutation in permutations:

--- a/dodos/action.py
+++ b/dodos/action.py
@@ -30,15 +30,28 @@ def task_action_generation():
     """
     Action generation: generate actions to choose from.
     """
+
+    def generate_actions(args):
+        cmd = f"python3 ./action/generation/generate_create_index_tpcc.py --output-sql {ARTIFACT_ACTIONS} {args}"
+        return cmd
+
     return {
         "actions": [
             f"mkdir -p {ARTIFACTS_PATH}",
             # Generate create index suggestions for TPC-C.
-            f"python3 ./action/generation/generate_create_index_tpcc.py --min-num-cols 1 --max-num-cols 4 --output-sql {ARTIFACT_ACTIONS}",
+            CmdAction(generate_actions),
         ],
         "file_dep": ["./action/generation/generate_create_index_tpcc.py"],
         "targets": [ARTIFACT_ACTIONS],
+        "uptodate": [False],
         "verbosity": VERBOSITY_DEFAULT,
+        "params": [
+            {
+                "name": "args",
+                "long": "args",
+                "default": "--min-num-cols 1 --max-num-cols 4",
+            },
+        ],
     }
 
 


### PR DESCRIPTION
Add filtered tables for TPC-C create index actions.

- Currently just an option to use a hardcoded filtered schema.
- The corresponding dodo task is also extended to take args.
  - Sample usage: `doit action_generation --args="--min-num-cols 1 --max-num-cols 4 --filter-tables"`