### PR TITLE
Add model inference via a local Flask app.

### DIFF
--- a/behavior/__main__.py
+++ b/behavior/__main__.py
@@ -3,6 +3,7 @@ import logging
 from plumbum import cli
 
 from behavior.datagen import gen
+from behavior.microservice import app
 from behavior.modeling import train
 from behavior.plans import diff
 
@@ -19,4 +20,5 @@ if __name__ == "__main__":
     BehaviorCLI.subcommand("datagen", gen.DataGeneratorCLI)
     BehaviorCLI.subcommand("datadiff", diff.DataDiffCLI)
     BehaviorCLI.subcommand("train", train.TrainCLI)
+    BehaviorCLI.subcommand("microservice", app.ModelMicroserviceCLI)
     BehaviorCLI.run()

--- a/behavior/microservice/app.py
+++ b/behavior/microservice/app.py
@@ -1,0 +1,72 @@
+import pickle
+from pathlib import Path
+from typing import Dict
+
+import numpy as np
+from flask import Flask, jsonify, request
+from plumbum import cli
+
+from behavior.modeling.model import BehaviorModel
+
+app = Flask(__name__)
+app.config["DEBUG"] = True
+
+
+@app.route("/model/<model_type>/<ou_type>/", methods=["GET"])
+def infer(model_type, ou_type):
+    # Get the behavior model.
+    try:
+        behavior_model: BehaviorModel = app.config["model_map"][model_type][ou_type]
+    except KeyError as err:
+        return f"Error: {err}"
+
+    # Check that all the features are present.
+    diff = set(behavior_model.features).difference(request.args)
+    if len(diff) > 0:
+        return f"Features missing: {diff}"
+
+    # Extract the features.
+    X = [request.args[feature] for feature in behavior_model.features]
+    X = np.array(X).astype(float).reshape(1, -1)
+
+    # Predict the Y values.
+    Y = behavior_model.predict(X)
+    assert Y.shape[0] == 1
+    Y = Y[0]
+
+    # Label and return the Y values.
+    Y = dict(zip(behavior_model.targets, Y))
+    return jsonify(Y)
+
+
+class ModelMicroserviceCLI(cli.Application):
+    models_path = cli.SwitchAttr("--models-path", Path, mandatory=True)
+
+    def main(self, *args):
+        self.models_path = self.models_path.absolute()
+
+        model_map: Dict[str, Dict[str, BehaviorModel]] = {}
+        # Load all the models in memory for inference.
+        for model_type_path in self.models_path.glob("*"):
+            model_type = model_type_path.name
+            model_map[model_type] = model_map.get(model_type, {})
+            for ou_type_path in model_type_path.glob("*"):
+                ou_type = ou_type_path.name
+
+                model_path = list(ou_type_path.glob("*.pkl"))
+                assert len(model_path) == 1
+                model_path = model_path[0]
+
+                print(model_type, ou_type, model_path)
+                with open(model_path, "rb") as model_file:
+                    model = pickle.load(model_file)
+                    model_map[model_type][ou_type] = model
+
+        # Expose the models to the Flask app.
+        app.config["model_map"] = model_map
+        # Run the Flask app.
+        app.run()
+
+
+if __name__ == "__main__":
+    ModelMicroserviceCLI.run()

--- a/behavior/modeling/model.py
+++ b/behavior/modeling/model.py
@@ -131,4 +131,4 @@ class BehaviorModel:
     def save(self) -> None:
         model_dir = self.output_dir / self.timestamp / self.method / self.ou_name
         with open(model_dir / f"{self.method}_{self.ou_name}.pkl", "wb") as f:
-            pickle.dump(self.model, f)
+            pickle.dump(self, f)

--- a/dodos/behavior.py
+++ b/dodos/behavior.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+from plumbum import local
+
 import dodos.benchbase
 import dodos.noisepage
 from dodos import VERBOSITY_DEFAULT, default_artifacts_path, default_build_path
@@ -78,5 +80,28 @@ def task_behavior_train():
             f"python3 -m behavior train {train_args}",
         ],
         "targets": [ARTIFACT_MODELS],
+        "verbosity": VERBOSITY_DEFAULT,
+    }
+
+
+def task_behavior_microservice():
+    """
+    Behavior modeling: models as a microservice (via Flask).
+    """
+
+    def run_microservice():
+        # Find the latest experiment.
+        # TODO(WAN): Make this configurable.
+        experiment_list = sorted(exp_path for exp_path in ARTIFACT_MODELS.glob("*"))
+        assert len(experiment_list) > 0, "No experiments found."
+        experiment_name = experiment_list[-1]
+
+        server_cmd = local["python3"]["-m", "behavior", "microservice", "--models-path", experiment_name]
+        dest_stdout = "behavior_microservice.out"
+        ret = server_cmd.run_nohup(stdout=dest_stdout)
+        print(f"Behavior models microservice: {dest_stdout} {ret.pid}")
+
+    return {
+        "actions": [run_microservice],
         "verbosity": VERBOSITY_DEFAULT,
     }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ combine_as_imports = true
 
 [tool.pylint.master]
 jobs = 4
-good-names = ["i", "j", "k", "v", "e", "df", "f", "fp", "X", "x", "y", "db"]
+good-names = ["i", "j", "k", "v", "e", "df", "f", "fp", "X", "x", "y", "Y", "db"]
 
 [tool.pylint.format]
 max-line-length=120

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 black
 doit
 flake8
+flask
 isort
 lightgbm
 numpy>=1.20 # numpy.typing.


### PR DESCRIPTION
Add model inference via a local Flask app.

- Add `flask` as a dependency.
- Add `behavior_microservice` task.
- Add "Y" as a valid variable name since we already have "x", "X", "y" anyway.
- Save the entire BehaviorModel to maintain labels for features and targets.

Sample usage:

- If you have no models, run `behavior_datagen` and `behavior_train` first.
- `doit behavior_microservice`
  - This uses the latest set of models by default.
  - You can see the output being redirected to `behavior_microservice.out`.
- Go to `http://localhost:5000/model/<MODEL_TYPE>/<MODEL_NAME>/?<FEATURES>`
  - For example, `http://127.0.0.1:5000/model/dt/SeqScan/?total_cost=123&plan_width=123&startup_cost=123&diffed_total_cost=123&Scan_plan_parallel_safe=0`