### PR TITLE
Fix dodo quirks in benchbase_run and action_recommendation.

### DIFF
--- a/dodos/action.py
+++ b/dodos/action.py
@@ -172,7 +172,7 @@ def task_action_recommendation():
     Action recommendation: apply recommended actions to the DBMS.
     """
 
-    def index_picker(batch_size, db_conn_string):
+    def index_picker(batch_size, db_conn_string, database_game_args):
         action = (
             "python3 ./action/recommendation/index_picker.py "
             # index_picker.py arguments.
@@ -183,6 +183,7 @@ def task_action_recommendation():
             f'--db_conn_string "{db_conn_string}" '
             f"--actions_path {ARTIFACT_ACTIONS} "
             f"--forecast_path {dodos.forecast.ARTIFACT_FORECAST} "
+            f"{database_game_args} "
         )
         return action
 
@@ -192,7 +193,10 @@ def task_action_recommendation():
             "./action/recommendation/index_picker.py",
             ARTIFACT_ACTIONS,
             ARTIFACT_DATABASE_GAME,
-            dodos.forecast.ARTIFACT_FORECAST,
+            # TODO(WAN): Unfortunately, action_recommendation is usually invoked after a separate initialization
+            #  that generated a forecast already. Expressing this dependency causes us to try to recompute a forecast,
+            #  which fails exactly because we want to start from a clean slate DBMS-wise.
+            # dodos.forecast.ARTIFACT_FORECAST,
         ],
         "verbosity": VERBOSITY_DEFAULT,
         "uptodate": [False],
@@ -210,6 +214,12 @@ def task_action_recommendation():
                 "long": "db_conn_string",
                 "help": "The database connection string to use.",
                 "default": DB_CONN_STRING_AS_SPIEL,
+            },
+            {
+                "name": "database_game_args",
+                "long": "database_game_args",
+                "help": "Additional arguments to pass to database_game.",
+                "default": "",
             },
         ],
     }

--- a/dodos/benchbase.py
+++ b/dodos/benchbase.py
@@ -129,8 +129,12 @@ def task_benchbase_run():
 
     def invoke_benchbase(benchmark, config, args):
         if config is None:
-            config = ARTIFACTS_PATH / f"config/postgres/sample_{benchmark}_config.xml"
-
+            config = ARTIFACTS_PATH / f"config/postgres/{benchmark}_config.xml"
+        elif not config.startswith('/'):
+            # If config is not an absolute path,
+            # because we must be in the BenchBase folder for the java invocation to work out,
+            # we need to get the original relative path that the caller intended.
+            config = (Path(doit.get_initial_workdir()) / config).absolute()
         return f"java -jar benchbase.jar -b {benchmark} -c {config} {args}"
 
     return {


### PR DESCRIPTION
Fix dodo quirks in benchbase_run and action_recommendation.

- For action_recommendation, we don't always want to recompute the forecast.
  Specifically, the forecast DB can be different from the action selection DB.
- Support passing database_game_args in action_recommendation.
- Add additional logic in benchbase_run to figure out the right config path.