### PR TITLE
Add inference via microservice to database_game.

### DIFF
--- a/action/selection/open_spiel/CMakeLists.txt
+++ b/action/selection/open_spiel/CMakeLists.txt
@@ -5,12 +5,28 @@ set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 include(FetchContent)
 FetchContent_Declare(
+        cpp-httplib
+        GIT_REPOSITORY https://github.com/yhirose/cpp-httplib.git
+        GIT_TAG master
+        GIT_SHALLOW TRUE
+        GIT_PROGRESS TRUE
+)
+FetchContent_Declare(
         open_spiel
         GIT_REPOSITORY https://github.com/deepmind/open_spiel.git
         GIT_TAG master
         GIT_SHALLOW TRUE
         GIT_PROGRESS TRUE
 )
+FetchContent_Declare(
+        rapidjson
+        GIT_REPOSITORY https://github.com/Tencent/rapidjson.git
+        GIT_TAG master
+        GIT_SHALLOW TRUE
+        GIT_PROGRESS TRUE
+)
+
+FetchContent_MakeAvailable(cpp-httplib)
 
 FetchContent_GetProperties(open_spiel)
 if (NOT open_spiel_POPULATED)
@@ -32,6 +48,10 @@ if (NOT open_spiel_POPULATED)
     # TODO(WAN): EXCLUDE_FROM_ALL targets should be "excluded from IDE project files",
     #   but CLion misbehaves: https://youtrack.jetbrains.com/issue/CPP-1688
     #   As a usability workaround, we ship a default .idea/runConfigurations.
+    # TODO(WAN): CMake is living proof that computers were a mistake.
+    #   There's no point documenting why, CMake hasn't provided workarounds for add_subdirectory() targets
+    #   for over a decade and you either know what I'm talking about or you don't.
+    #   Duplicate build logic?
     add_subdirectory(${open_spiel_SOURCE_DIR}/open_spiel ${open_spiel_BINARY_DIR} EXCLUDE_FROM_ALL)
 
     # Reset environment variables.
@@ -40,14 +60,21 @@ if (NOT open_spiel_POPULATED)
     set(ENV{BUILD_TYPE} ${BUILD_TYPE_OLD})
 endif ()
 
+FetchContent_GetProperties(rapidjson)
+if (NOT rapidjson_POPULATED)
+    FetchContent_Populate(rapidjson)
+endif ()
+
 add_executable(database_game database.h database.cc database_game.cc)
 target_include_directories(database_game SYSTEM PRIVATE ${open_spiel_SOURCE_DIR})
 target_include_directories(database_game SYSTEM PRIVATE ${open_spiel_SOURCE_DIR}/open_spiel/abseil-cpp)
+target_include_directories(database_game SYSTEM PRIVATE ${rapidjson_SOURCE_DIR}/include)
 target_link_libraries(
         database_game           # The database game solver.
         absl::flags             # Command line flags.
         absl::flags_parse       # Command line flags.
         absl::random_random     # Probability distributions.
+        httplib::httplib        # infer() to a web server.
         open_spiel              # OpenSpiel shared library.
         pqxx                    # Connecting to PostgreSQL.
 )

--- a/action/selection/open_spiel/database.h
+++ b/action/selection/open_spiel/database.h
@@ -5,6 +5,10 @@
 
 #include "open_spiel/spiel.h"
 
+namespace httplib {
+class Client;
+}
+
 namespace open_spiel {
 namespace database {
 
@@ -95,6 +99,9 @@ class DatabaseGame : public Game {
   // Knobs and configuration.
   const std::string &GetDatabaseConnectionString() const { return db_conn_string_; }
   bool UseHypoPG() const { return use_hypopg_; }
+  bool UseMicroservice() const { return use_microservice_; }
+
+  httplib::Client *GetMicroserviceClient() const { return microservice_client_.get(); }
 
  private:
   std::string db_conn_string_;
@@ -102,6 +109,10 @@ class DatabaseGame : public Game {
   std::unique_ptr<Tuner> tuner_;
   int max_tuning_actions_;
   bool use_hypopg_;
+  bool use_microservice_;
+
+  // use_microservice_ options.
+  std::unique_ptr<httplib::Client> microservice_client_;
 };
 
 }  // namespace database

--- a/action/selection/open_spiel/database_game.cc
+++ b/action/selection/open_spiel/database_game.cc
@@ -17,7 +17,8 @@ ABSL_FLAG(std::string, db_conn_string,
 ABSL_FLAG(std::string, forecast_path, "./forecast.csv", "Path to CSV of forecasted SQL queries.");
 ABSL_FLAG(std::string, actions_path, "./actions.csv", "Path to CSV of possible SQL actions.");
 ABSL_FLAG(int, max_tuning_actions, 1, "Maximum number of tuning actions before the game ends.");
-ABSL_FLAG(bool, use_hypopg, true, "True if hypopg should be used.");
+ABSL_FLAG(bool, use_hypopg, true, "True if hypopg should be used for faking index builds.");
+ABSL_FLAG(bool, use_microservice, false, "True if microservice should be used for inference.");
 
 // Solver type.
 ABSL_FLAG(std::string, solver_type, "cfr", "Solver to use. {cfr,mcts}.");
@@ -58,6 +59,7 @@ int main(int argc, char **argv) {
   params.emplace("actions_path", absl::GetFlag(FLAGS_actions_path));
   params.emplace("max_tuning_actions", absl::GetFlag(FLAGS_max_tuning_actions));
   params.emplace("use_hypopg", absl::GetFlag(FLAGS_use_hypopg));
+  params.emplace("use_microservice", absl::GetFlag(FLAGS_use_microservice));
 
   std::cerr << "Generic game parameters:" << std::endl;
   for (const auto &param : params) {


### PR DESCRIPTION
Add inference via microservice to database_game.

- Makes a HTTP request for each node in the EXPLAIN (FORMAT JSON) output.
  In total, it makes O(num_actions * num_queries_forecasted) HTTP requests.
- This feature is gated by `use_microservice`, disabled by default.
- This "feature" is predictably extremely slow. Only for demos.