### PR TITLE
Add demo/mvp.sh.

### DIFF
--- a/action/recommendation/index_picker.py
+++ b/action/recommendation/index_picker.py
@@ -102,10 +102,15 @@ class IndexPickerCLI(cli.Application):
                         # Get the recommended action.
                         # TODO(WAN): Hack. Better interface?
                         action = stdout.strip()
+                        err_lines = set()
                         for line in stderr.split("\n"):
                             if line.startswith("\tFinal returns:"):
                                 val_str = line.split(":")[1].strip()
                                 current_returns = float(val_str)
+                            if line.startswith("ERROR"):
+                                err_lines.add(line)
+                        for line in sorted(err_lines):
+                            print(line)
 
                         # Always remove the recommended action from the
                         # current batch of actions.

--- a/action/selection/open_spiel/database.cc
+++ b/action/selection/open_spiel/database.cc
@@ -160,6 +160,7 @@ struct ExplainMicroserviceCost {
     // TODO(WAN): Robustness for checking that node is a Plan from PostgreSQL's EXPLAIN (FORMAT JSON).
 
     std::vector<std::string> args{
+        absl::StrCat("bias=", "1"),
         absl::StrCat("startup_cost=", std::to_string(node["Startup Cost"].GetDouble()).c_str()),
         absl::StrCat("total_cost=", std::to_string(node["Total Cost"].GetDouble()).c_str()),
         absl::StrCat("plan_rows=", std::to_string(node["Plan Rows"].GetInt64()).c_str()),

--- a/behavior/microservice/app.py
+++ b/behavior/microservice/app.py
@@ -7,6 +7,7 @@ import setproctitle
 from flask import Flask, jsonify, request
 from plumbum import cli
 
+from behavior import DIFFED_TARGET_COLS
 from behavior.modeling.model import BehaviorModel
 
 app = Flask(__name__)
@@ -36,7 +37,7 @@ def infer(model_type, ou_type):
     Y = Y[0]
 
     # Label and return the Y values.
-    Y = dict(zip(behavior_model.targets, Y))
+    Y = dict(zip(DIFFED_TARGET_COLS, Y))
     return jsonify(Y)
 
 

--- a/behavior/microservice/app.py
+++ b/behavior/microservice/app.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import Dict
 
 import numpy as np
+import setproctitle
 from flask import Flask, jsonify, request
 from plumbum import cli
 
@@ -64,6 +65,7 @@ class ModelMicroserviceCLI(cli.Application):
 
         # Expose the models to the Flask app.
         app.config["model_map"] = model_map
+        setproctitle.setproctitle("Behavior Models Microservice")
         # Run the Flask app.
         app.run()
 

--- a/demo/mvp.sh
+++ b/demo/mvp.sh
@@ -3,8 +3,13 @@ set -ex
 # Various steps may require sudo.
 sudo --validate
 
+# Increase file descriptor limit for TScout.
+ulimit -n 8096
+
 # Clean up the result of previous runs, if any.
 doit ci_clean_slate
+sudo pkill postgres || true
+doit behavior_microservice_kill
 
 # Behavior models need to be trained.
 # Because the behavior code was written prior to pilot/dodo,
@@ -26,10 +31,13 @@ doit noisepage_enable_logging
 doit benchbase_run --benchmark="tpcc" --args="--execute=true"
 doit noisepage_disable_logging
 
+# Because BenchBase scales down the workload, we would end up predicting nothing by default.
+# We hack around it by deleting the last few query log files.
+doit noisepage_truncate_log
+
 # Predict the forecast manually because we need to control the time for now.
 # Otherwise it would default to predicting [now, now+1 minute].
-# TODO(WAN): Eventually, figure out the truncation problem.
-doit forecast_predict --time_start='2022-01-20 08:05:00 EST' --time_end='2022-01-20 08:30:00 EST'
+doit forecast_predict
 
 ##############################################################################
 # After this line, both forecast and behavior models should be ready.
@@ -48,12 +56,13 @@ doit action_recommendation_bootstrap_dbms
 
 # We need to load the same schema as the forecast.
 # TODO(WAN): Editing XML can be such a pain...
+mkdir -p artifacts/demo/
 sudo apt-get install xmlstarlet
-cp ./config/behavior/benchbase/tpcc_config.xml ./demo/mvp_tpcc_config.xml
-xmlstarlet edit --inplace --update '/parameters/url' --value 'jdbc:postgresql://localhost:5432/np_as_spiel?preferQueryMode=extended' ./demo/mvp_tpcc_config.xml
-xmlstarlet edit --inplace --update '/parameters/username' --value 'np_as_spiel_user' ./demo/mvp_tpcc_config.xml
-xmlstarlet edit --inplace --update '/parameters/password' --value 'np_as_spiel_pass' ./demo/mvp_tpcc_config.xml
-doit benchbase_run --benchmark="tpcc" --config="./demo/mvp_tpcc_config.xml" --args="--create=true --load=true"
+cp ./config/behavior/benchbase/tpcc_config.xml ./artifacts/demo/mvp_tpcc_config.xml
+xmlstarlet edit --inplace --update '/parameters/url' --value 'jdbc:postgresql://localhost:5432/np_as_spiel?preferQueryMode=extended' ./artifacts/demo/mvp_tpcc_config.xml
+xmlstarlet edit --inplace --update '/parameters/username' --value 'np_as_spiel_user' ./artifacts/demo/mvp_tpcc_config.xml
+xmlstarlet edit --inplace --update '/parameters/password' --value 'np_as_spiel_pass' ./artifacts/demo/mvp_tpcc_config.xml
+doit benchbase_run --benchmark="tpcc" --config="./artifacts/demo/mvp_tpcc_config.xml" --args="--create=true --load=true"
 # And then we need to drop those two TPC-C indexes.
 PGPASSWORD=np_as_spiel_pass ./artifacts/noisepage/psql -h localhost -d np_as_spiel -U np_as_spiel_user -c "DROP INDEX idx_customer_name;"
 PGPASSWORD=np_as_spiel_pass ./artifacts/noisepage/psql -h localhost -d np_as_spiel -U np_as_spiel_user -c "DROP INDEX idx_order;"

--- a/demo/mvp.sh
+++ b/demo/mvp.sh
@@ -1,0 +1,68 @@
+set -ex
+
+# Various steps may require sudo.
+sudo --validate
+
+# Clean up the result of previous runs, if any.
+doit ci_clean_slate
+
+# Behavior models need to be trained.
+# Because the behavior code was written prior to pilot/dodo,
+# datagen in particular doesn't quite fit the rest of the framework
+# in that it opaquely wraps the data generation pipeline.
+# This prevents it from composing with new dodo tasks.
+# It's not a big deal; probably not worth refactoring right now.
+doit behavior_datagen
+doit behavior_train
+
+# Forecast: generate training data.
+# This is annoying to automate because we need to enable/disable
+# logging and also customize the workload we want, so we don't.
+doit noisepage_init
+doit benchbase_overwrite_config
+doit benchbase_bootstrap_dbms
+doit benchbase_run --benchmark="tpcc" --args="--create=true --load=true"
+doit noisepage_enable_logging
+doit benchbase_run --benchmark="tpcc" --args="--execute=true"
+doit noisepage_disable_logging
+
+# Predict the forecast manually because we need to control the time for now.
+# Otherwise it would default to predicting [now, now+1 minute].
+# TODO(WAN): Eventually, figure out the truncation problem.
+doit forecast_predict --time_start='2022-01-20 08:05:00 EST' --time_end='2022-01-20 08:30:00 EST'
+
+##############################################################################
+# After this line, both forecast and behavior models should be ready.
+##############################################################################
+
+# Start the inference microservice.
+doit behavior_microservice
+
+# Start with a fresh copy of NoisePage.
+doit noisepage_init
+
+# Install HypoPG.
+doit action_selection_hypopg_install
+# Bootstrap the DBMS for action recommendation.
+doit action_recommendation_bootstrap_dbms
+
+# We need to load the same schema as the forecast.
+# TODO(WAN): Editing XML can be such a pain...
+sudo apt-get install xmlstarlet
+cp ./config/behavior/benchbase/tpcc_config.xml ./demo/mvp_tpcc_config.xml
+xmlstarlet edit --inplace --update '/parameters/url' --value 'jdbc:postgresql://localhost:5432/np_as_spiel?preferQueryMode=extended' ./demo/mvp_tpcc_config.xml
+xmlstarlet edit --inplace --update '/parameters/username' --value 'np_as_spiel_user' ./demo/mvp_tpcc_config.xml
+xmlstarlet edit --inplace --update '/parameters/password' --value 'np_as_spiel_pass' ./demo/mvp_tpcc_config.xml
+doit benchbase_run --benchmark="tpcc" --config="./demo/mvp_tpcc_config.xml" --args="--create=true --load=true"
+# And then we need to drop those two TPC-C indexes.
+PGPASSWORD=np_as_spiel_pass ./artifacts/noisepage/psql -h localhost -d np_as_spiel -U np_as_spiel_user -c "DROP INDEX idx_customer_name;"
+PGPASSWORD=np_as_spiel_pass ./artifacts/noisepage/psql -h localhost -d np_as_spiel -U np_as_spiel_user -c "DROP INDEX idx_order;"
+
+# Manually generate actions because we want to pass the --filter-tables flag.
+# Filtering because infer() as a microservice is, unsurprisingly, extremely slow.
+doit action_generation --args="--min-num-cols 1 --max-num-cols 4 --filter-tables"
+
+# Start picking indexes.
+doit action_recommendation --database_game_args="--use_microservice"
+
+sudo --reset-timestamp

--- a/dodos/behavior.py
+++ b/dodos/behavior.py
@@ -105,3 +105,15 @@ def task_behavior_microservice():
         "actions": [run_microservice],
         "verbosity": VERBOSITY_DEFAULT,
     }
+
+
+def task_behavior_microservice_kill():
+    """
+    Behavior modeling: kill all running microservices.
+    """
+    return {
+        "actions": [
+            "pkill --full '^Behavior Models Microservice' || true",
+        ],
+        "verbosity": VERBOSITY_DEFAULT,
+    }

--- a/dodos/behavior.py
+++ b/dodos/behavior.py
@@ -97,7 +97,7 @@ def task_behavior_microservice():
         experiment_name = experiment_list[-1]
 
         server_cmd = local["python3"]["-m", "behavior", "microservice", "--models-path", experiment_name]
-        dest_stdout = "behavior_microservice.out"
+        dest_stdout = "artifacts/behavior/microservice.out"
         ret = server_cmd.run_nohup(stdout=dest_stdout)
         print(f"Behavior models microservice: {dest_stdout} {ret.pid}")
 

--- a/dodos/benchbase.py
+++ b/dodos/benchbase.py
@@ -91,7 +91,7 @@ def task_benchbase_overwrite_config():
             lambda: os.chdir(doit.get_initial_workdir()),
         ],
         "file_dep": [*CONFIG_FILES.glob("*")],
-        "uptodate": [True],
+        "uptodate": [False],
         "verbosity": VERBOSITY_DEFAULT,
     }
 

--- a/dodos/noisepage.py
+++ b/dodos/noisepage.py
@@ -178,3 +178,28 @@ def task_noisepage_disable_logging():
         ],
         "verbosity": VERBOSITY_DEFAULT,
     }
+
+
+def task_noisepage_truncate_log():
+    """
+    NoisePage: truncate the most recent query log files.
+    """
+
+    return {
+        "actions": [
+            lambda: os.chdir(ARTIFACT_pgdata_log),
+            'RECENT=$(ls --sort=time --reverse *.csv | head --lines=%(num_files)s) ; echo "Deleting:\n$RECENT" ; rm $RECENT ; echo "Deleted."',
+            # Reset working directory.
+            lambda: os.chdir(doit.get_initial_workdir()),
+        ],
+        "verbosity": VERBOSITY_DEFAULT,
+        "uptodate": [False],
+        "params": [
+            {
+                "name": "num_files",
+                "long": "num_files",
+                "help": "The number of query log files to remove.",
+                "default": 5,
+            },
+        ],
+    }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,9 @@ combine_as_imports = true
 [tool.pylint.master]
 jobs = 4
 good-names = ["i", "j", "k", "v", "e", "df", "f", "fp", "X", "x", "y", "Y", "db"]
+extension-pkg-allow-list = [
+    "setproctitle",
+]
 
 [tool.pylint.format]
 max-line-length=120

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ pydotplus
 pylint
 pyyaml
 scikit-learn>=1.0.0 # Behavior models.
+setproctitle
 torch # Forecast. LSTM.
 toml
 tqdm


### PR DESCRIPTION
Add `demo/mvp.sh`.

The `demo/mvp.sh` script demonstrates full end-to-end:

1. Modeling.
  a. Collecting training data from NoisePage and TScout.
  b. Building models from training data.
  c. (demo hack) Inference as a microservice over a REST endpoint.
2. Forecasting.
  a. Collecting workload trace from NoisePage.
  b. Extracting query templates, clustering, and building models for said trace.
  c. Generating a workload forecast for a given interval.
3. Action planning.
  a. Setting up the DBMS with necessary databases, tables, extensions, etc.
  b. Loading the same schema as the forecast.
  c. Generating TPC-C CREATE INDEX actions.
  d. Selecting good candidate actions with an OpenSpiel CFR solver.
  e. Applying recommended actions with a Python script.


This PR introduces:

- Printing out errors in `index_picker.py`.
- Updates to the OpenSpiel code to work with the current implementation of behavior models.
- `setproctitle` to make it easier to find and kill the behavior microservice.
- Small dodo fixes: always run `benchbase_overwrite_config`, move microservice log to `./artifacts/behavior/microservice.out`.
- `noisepage_truncate_log`: a hack around the winding-down behavior of BenchBase; we truncate the last N (default 5) query log CSV files.