### PR TITLE
Add support for `doit ci_python check=true`, use in GitHub Actions.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,4 +18,4 @@ jobs:
       - run: python -m pip install --user --upgrade pip setuptools wheel build
       - run: python -m build .
       - run: pip install . -r requirements.txt
-      - run: doit ci_python
+      - run: doit ci_python check=true

--- a/dodos/benchbase.py
+++ b/dodos/benchbase.py
@@ -130,7 +130,7 @@ def task_benchbase_run():
     def invoke_benchbase(benchmark, config, args):
         if config is None:
             config = ARTIFACTS_PATH / f"config/postgres/{benchmark}_config.xml"
-        elif not config.startswith('/'):
+        elif not config.startswith("/"):
             # If config is not an absolute path,
             # because we must be in the BenchBase folder for the java invocation to work out,
             # we need to get the original relative path that the caller intended.

--- a/dodos/ci.py
+++ b/dodos/ci.py
@@ -1,3 +1,5 @@
+from doit import get_var
+
 from dodos import VERBOSITY_DEFAULT
 
 
@@ -21,13 +23,12 @@ def task_ci_python():
     CI: this should be run and all warnings fixed before pushing commits.
     """
     folders = ["action", "behavior", "dodos", "forecast", "pilot"]
+    config = {"check": "--check" if str(get_var("check")).lower() == "true" else ""}
 
     return {
         "actions": [
-            "black --verbose dodo.py",
-            "isort --verbose dodo.py",
-            *[f"black --verbose {folder}" for folder in folders],
-            *[f"isort {folder}" for folder in folders],
+            *[f"black {config['check']} --verbose {folder}" for folder in folders],
+            *[f"isort {config['check']} {folder}" for folder in folders],
             *[f"flake8 --statistics {folder}" for folder in folders],
             # TODO(WAN): Only run pylint on behavior for now.
             *[f"pylint --verbose {folder}" for folder in ["behavior"]],


### PR DESCRIPTION
Add support for `doit ci_python check=true`, use in GitHub Actions.

This passes the `--check` flag to `black` and `isort`,
ensuring that checked-in code will be compliant.

Also fix any existing files that sneaked in.
