### PR TITLE
Parameterize workload forecasting arguments (with defaults).

### DIFF
--- a/dodos/forecast.py
+++ b/dodos/forecast.py
@@ -158,7 +158,7 @@ def task_forecast_predict():
             {
                 "name": "pred_seqlen",
                 "long": "pred_seqlen",
-                "help": "How many consecutive intervals of query arrival rate is used to make inference.",
+                "help": "Number of consecutive query arrival rate intervals that are used for inference.",
                 "type": int,
                 "default": DEFAULT_PRED_SEQLEN,
             },

--- a/dodos/forecast.py
+++ b/dodos/forecast.py
@@ -76,17 +76,14 @@ def task_forecast_predict():
     Forecast: produce predictions for the given time range.
     """
 
-    # Read the query log timestamps from the preprocessor's output.
-    with open(PREPROCESSOR_TIMESTAMP) as ts_file:
-        lines = ts_file.readlines()
-        assert len(lines) == 2, "Timestamp file should have two lines with a timestamp each."
-        log_start = pd.Timestamp(lines[0])
-        log_end = pd.Timestamp(lines[1])
-
     def forecast_action(pred_start, pred_end, pred_horizon, pred_interval, pred_seqlen):
-        nonlocal log_start, log_end
-        log_start = log_start.floor(pred_interval)
-        log_end = log_end.floor(pred_interval)
+        # Read the query log timestamps from the preprocessor's output.
+        # TODO(WAN): This file is read repeatedly!
+        with open(PREPROCESSOR_TIMESTAMP) as ts_file:
+            lines = ts_file.readlines()
+            assert len(lines) == 2, "Timestamp file should have two lines with a timestamp each."
+            log_start = pd.Timestamp(lines[0]).floor(pred_interval)
+            log_end = pd.Timestamp(lines[1]).floor(pred_interval)
 
         # Infer the prediction window from the query log and default parameters.
         if pred_start is None:

--- a/dodos/forecast.py
+++ b/dodos/forecast.py
@@ -9,8 +9,6 @@ BUILD_PATH = default_build_path()
 
 # Input: query log.
 QUERY_LOG_DIR = dodos.noisepage.ARTIFACT_pgdata_log
-from pathlib import Path
-QUERY_LOG_DIR = Path("/home/mkpjnx/repos/noisepage-pilot/forecast/data/extracted/long_simple")
 
 # Scratch work.
 PREPROCESSOR_ARTIFACT = BUILD_PATH / "preprocessed.parquet.gzip"
@@ -87,13 +85,13 @@ def task_forecast_predict():
             log_start = pd.Timestamp(lines[0]).floor(pred_interval)
             log_end = pd.Timestamp(lines[1]).floor(pred_interval)
 
-        # The minimum prediction horizon needed
+        # Infer the prediction window from the query log and default params.
         if pred_start is None:
             pred_start = log_end + pred_interval
         if pred_end is None:
             pred_end = log_end + pred_horizon
 
-        # TODO(Mike): assert there is enough data for inference
+        # TODO(Mike): Assert there is enough data for inference.
         print(
             f"Using query data ({log_start.isoformat()} to {log_end.isoformat()})\n"
             f"to predict ({pred_start.isoformat()} to {pred_end.isoformat()})\n"
@@ -126,35 +124,35 @@ def task_forecast_predict():
             {
                 "name": "pred_start",
                 "long": "pred_start",
-                "help": "The start point of the forecast (inclusive). Default: now.",
+                "help": "The start point of the forecast (inclusive). Default: last timestamp in the query log.",
                 "type": pd.Timestamp,
                 "default": None,
             },
             {
                 "name": "pred_end",
                 "long": "pred_end",
-                "help": "The end point of the forecast (inclusive). Default: 1 minute from now.",
+                "help": "The end point of the forecast (inclusive). Default: 10 seconds from pred_start.",
                 "type": pd.Timestamp,
                 "default": None,
             },
             {
                 "name": "pred_horizon",
                 "long": "pred_horizon",
-                "help": "The end point of the forecast (inclusive). Default: 1 minute from now.",
+                "help": "How far in the future to predict.",
                 "type": pd.Timedelta,
                 "default": DEFAULT_PRED_HORIZON,  # Infer horizon from file if needed
             },
             {
                 "name": "pred_interval",
                 "long": "pred_interval",
-                "help": "The end point of the forecast (inclusive). Default: 1 minute from now.",
+                "help": "Interval to aggregate the queries for training/prediction.",
                 "type": pd.Timedelta,
                 "default": DEFAULT_PRED_INTERVAL,
             },
             {
                 "name": "pred_seqlen",
                 "long": "pred_seqlen",
-                "help": "The end point of the forecast (inclusive). Default: 1 minute from now.",
+                "help": "How many consecutive intervals of query arrival rate is used to make inference.",
                 "type": int,
                 "default": DEFAULT_PRED_SEQLEN,
             },

--- a/dodos/forecast.py
+++ b/dodos/forecast.py
@@ -16,7 +16,7 @@ PREPROCESSOR_TIMESTAMP = BUILD_PATH / "preprocessed.timestamp.txt"
 CLUSTER_ARTIFACT = BUILD_PATH / "clustered.parquet"
 MODEL_DIR = BUILD_PATH / "models"
 
-# Default Forecasting Params
+# Default forecasting parameters.
 DEFAULT_PRED_HORIZON = pd.Timedelta(seconds=10)
 DEFAULT_PRED_INTERVAL = pd.Timedelta(seconds=1)
 DEFAULT_PRED_SEQLEN = 10
@@ -88,7 +88,7 @@ def task_forecast_predict():
         log_start = log_start.floor(pred_interval)
         log_end = log_end.floor(pred_interval)
 
-        # Infer the prediction window from the query log and default params.
+        # Infer the prediction window from the query log and default parameters.
         if pred_start is None:
             pred_start = log_end + pred_interval
         if pred_end is None:

--- a/dodos/forecast.py
+++ b/dodos/forecast.py
@@ -89,7 +89,7 @@ def task_forecast_predict():
         if pred_start is None:
             pred_start = log_end + pred_interval
         if pred_end is None:
-            pred_end = log_end + pred_horizon
+            pred_end = log_end + pred_horizon + pred_interval
 
         # TODO(Mike): Assert there is enough data for inference.
         # TODO(WAN): This entire callable may be invoked repeatedly, so print statements are not a good idea.

--- a/dodos/forecast.py
+++ b/dodos/forecast.py
@@ -144,15 +144,15 @@ def task_forecast_predict():
             {
                 "name": "pred_horizon",
                 "long": "pred_horizon",
-                "help": "How far in the future to predict.",
-                "type": pd.Timedelta,
+                "help": "How far in the future to predict (seconds).",
+                "type": lambda x: pd.Timedelta(seconds=int(x)),
                 "default": DEFAULT_PRED_HORIZON,  # Infer horizon from file if needed
             },
             {
                 "name": "pred_interval",
                 "long": "pred_interval",
-                "help": "Interval to aggregate the queries for training/prediction.",
-                "type": pd.Timedelta,
+                "help": "Interval (seconds) to aggregate the queries for training/prediction.",
+                "type": lambda x: pd.Timedelta(seconds=int(x)),
                 "default": DEFAULT_PRED_INTERVAL,
             },
             {

--- a/forecast/forecaster.py
+++ b/forecast/forecaster.py
@@ -137,7 +137,7 @@ class ClusterForecaster:
         if cluster not in cluster_df.index.get_level_values(0):
             return None
 
-        # No model for give cluster.
+        # No model for given cluster.
         if cluster not in self.models.keys():
             return None
 

--- a/forecast/forecaster.py
+++ b/forecast/forecaster.py
@@ -133,14 +133,13 @@ class ClusterForecaster:
         assert cluster_df.index.names[0] == "cluster"
         assert cluster_df.index.names[1] == "log_time_s"
 
+        # Cluster not in the data.
         if cluster not in cluster_df.index.get_level_values(0):
-            print(f"Could not find cluster {cluster} in cluster_df")
             return None
 
+        # No model for give cluster.
         if cluster not in self.models.keys():
-            print(f"Could not find model for cluster {cluster}")
             return None
-        
 
         cluster_counts = cluster_df[cluster_df.index.get_level_values(0) == cluster].droplevel(0)
 
@@ -293,7 +292,7 @@ class ForecasterCLI(cli.Application):
             end_time = pd.Timestamp(self.end_ts)
             pred_df = forecaster.predict(clustered_df, cluster, start_time, end_time)
             if pred_df is None:
-                print(f"No Prediction for {cluster}, not in top k clusters")
+                # No data or model for cluster.
                 continue
             prediction_count = pred_df["count"].sum()
             print(f"Prediction for {cluster}: {prediction_count}")

--- a/forecast/preprocessor.py
+++ b/forecast/preprocessor.py
@@ -424,6 +424,8 @@ class PreprocessorCLI(cli.Application):
 
     query_log_folder = cli.SwitchAttr("--query-log-folder", str, mandatory=True)
     output_parquet = cli.SwitchAttr("--output-parquet", str, mandatory=True)
+    output_timestamp = cli.SwitchAttr("--output-timestamp", str, default=None)
+
     log_type = cli.SwitchAttr(
         "--log-type",
         argtype=str,
@@ -458,6 +460,14 @@ class PreprocessorCLI(cli.Application):
         preprocessor = Preprocessor(pgfiles, log_columns)
         print("Storing parquet")
         preprocessor.get_dataframe().to_parquet(self.output_parquet, compression="gzip")
+
+        # Optionally write min and max timestamps of queries to infer forecast
+        # window
+        if self.output_timestamp is None:
+            return
+        with open(self.output_timestamp, "w") as ts_file:
+            ts_file.write(preprocessor.get_dataframe().index.min().isoformat() + "\n")
+            ts_file.write(preprocessor.get_dataframe().index.max().isoformat() + "\n")
 
 
 if __name__ == "__main__":

--- a/forecast/preprocessor.py
+++ b/forecast/preprocessor.py
@@ -461,8 +461,7 @@ class PreprocessorCLI(cli.Application):
         print("Storing parquet")
         preprocessor.get_dataframe().to_parquet(self.output_parquet, compression="gzip")
 
-        # Optionally write min and max timestamps of queries to infer forecast
-        # window
+        # Optionally write min and max timestamps of queries to infer forecast window.
         if self.output_timestamp is None:
             return
         with open(self.output_timestamp, "w") as ts_file:


### PR DESCRIPTION
Parameterize workload forecasting arguments (with defaults).

Add the following flags to `forecast_predict`:

- `pred_horizon`
    - How far in the future to predict (seconds), default 10s.
- `pred_interval`
    - Interval (seconds) to aggregate the queries for training/prediction, default 1s.
- `pred_seqlen`
    - Number of consecutive query arrival rate intervals that are used for inference, default 10.

These defaults correspond to 10 data points of arrivals/second being used
to predict the arrivals/second 10 seconds in the future. 
These defaults are arbitrarily chosen and may be changed.

Additionally, the default prediction window's start and end times,
`pred_start` and `pred_end`, are now based on the last timestamp
observed in the query log.
Specifically, it defaults to the first `pred_horizon`-length window
occurring `pred_interval` after the last observed timestamp.

The net effect of these changes are that `forecast_predict` should work out of the box.

---

Added flags to forecaster dodo and forecaster cli to support adjusting prediciton horizon, interval, and sequence length. By default, seqlen=10, interval=1s, horion=10s. This means that ten datapoints of arrivals/second are used to predict the arrivals/second 10 seconds in the future. These numbers are chosen somewhat arbitrarily and can be changed in the future to reflect the typical usage of workload forecasting.

Further, the start and end times of the prediction window is now based on the last timestamp observed in the query log. This means that the user invoking the forecaster should be able to use it "out of the box" to produce a workload forecast.