### PR TITLE
Add support for parameter sweeps in training data generation.

### DIFF
--- a/behavior/datagen/gen.py
+++ b/behavior/datagen/gen.py
@@ -575,7 +575,7 @@ class DataGeneratorCLI(cli.Application):
                         benchbase_results_dir,
                     )
 
-                    # Copy and inject the XML file of benchbase.
+                    # Copy and inject the XML file of BenchBase.
                     shutil.copy(input_cfg_path, benchbase_results_dir)
                     inject_param_xml((benchbase_results_dir / f"{benchmark}_config.xml").as_posix(), parameters)
 

--- a/behavior/datagen/gen.py
+++ b/behavior/datagen/gen.py
@@ -547,9 +547,14 @@ class DataGeneratorCLI(cli.Application):
                 def sweep_func(parameters, closure):
                     """Callback to datagen parameter sweep.
 
+                    Given the current set of parameters as part of the sweep, this callback:
+                    - Creates the result directory.
+                    - Creates the configuration XML for BenchBase.
+                    - Invokes BenchBase to generate training data.
+
                     Parameters:
                     -----------
-                    parameters: List[Tuple(List[str], Any)]
+                    parameters: List[Tuple[List[str], Any]]
                         The parameter combination.
                     closure : Dict[str, Any]
                         Closure environment passed from caller.

--- a/behavior/modeling/train.py
+++ b/behavior/modeling/train.py
@@ -257,14 +257,16 @@ def main(config_file, dir_data_train, dir_data_eval, dir_output):
         logger.info("Experiment name was not provided, using experiment: %s", experiment_name)
     else:
         experiment_name = config["experiment_name"]
-   
+
     train_exp_root = dir_data_train / experiment_name
-    all_train_names = sorted([d.name for d in train_exp_root.iterdir() if d.is_dir()\
-            and d.name.startswith(train_bench_db)])
+    all_train_names = sorted(
+        [d.name for d in train_exp_root.iterdir() if d.is_dir() and d.name.startswith(train_bench_db)]
+    )
 
     eval_exp_root = dir_data_eval / experiment_name
-    all_eval_names = sorted([d.name for d in eval_exp_root.iterdir() if d.is_dir()\
-            and d.name.startswith(eval_bench_db)])
+    all_eval_names = sorted(
+        [d.name for d in eval_exp_root.iterdir() if d.is_dir() and d.name.startswith(eval_bench_db)]
+    )
 
     # Verify that the training and evaluation data directories exist.
     if len(all_train_names) == 0 or len(all_eval_names) == 0:

--- a/behavior/modeling/train.py
+++ b/behavior/modeling/train.py
@@ -269,10 +269,12 @@ def main(config_file, dir_data_train, dir_data_eval, dir_output):
     )
 
     # Verify that the training and evaluation data directories exist.
-    if len(all_train_names) == 0 or len(all_eval_names) == 0:
-        raise ValueError(f"Benchmark data not found for experiment: {experiment_name}")
-    if len(all_train_names) != len(all_eval_names):
-        raise ValueError(f"Train/Eval cases mismatch for experiment: {experiment_name}")
+    assert (
+        len(all_train_names) > 0 and len(all_eval_names) > 0
+    ), f"Benchmark data not found for experiment: {experiment_name}\nMake sure you generated the full sets of data."
+    assert len(all_train_names) == len(
+        all_eval_names
+    ), f"Train/Eval cases mismatch for experiment: {experiment_name}\nMake sure you generated the full sets of data."
 
     for train_bench_name, eval_bench_name in zip(all_train_names, all_eval_names):
         training_data_dir = train_exp_root / train_bench_name

--- a/behavior/plans/diff.py
+++ b/behavior/plans/diff.py
@@ -468,6 +468,8 @@ def main(data_dir, output_dir, experiment) -> None:
 
     for mode in ["train", "eval"]:
         experiment_root: Path = data_dir / mode / experiment
+        # The data folders must have prefix as the selected benchmark names.
+        # Its suffix is the concatenated parameters.
         bench_names: list[str] = [
             d.name
             for d in experiment_root.iterdir()

--- a/behavior/plans/diff.py
+++ b/behavior/plans/diff.py
@@ -468,8 +468,9 @@ def main(data_dir, output_dir, experiment) -> None:
 
     for mode in ["train", "eval"]:
         experiment_root: Path = data_dir / mode / experiment
-        # The data folders must have prefix as the selected benchmark names.
-        # Its suffix is the concatenated parameters.
+        # The data folders must be prefixed by the name of the benchmark,
+        # and suffixed by the concatenated parameters.
+        # For example, `tpcc_scalefactor_0.1_terminals_1_rate_10000_time_60`.
         bench_names: list[str] = [
             d.name
             for d in experiment_root.iterdir()

--- a/behavior/plans/diff.py
+++ b/behavior/plans/diff.py
@@ -469,8 +469,9 @@ def main(data_dir, output_dir, experiment) -> None:
     for mode in ["train", "eval"]:
         experiment_root: Path = data_dir / mode / experiment
         bench_names: list[str] = [
-            d.name for d in experiment_root.iterdir() if d.is_dir()\
-            and d.name.startswith(tuple(BENCHDB_TO_TABLES.keys()))
+            d.name
+            for d in experiment_root.iterdir()
+            if d.is_dir() and d.name.startswith(tuple(BENCHDB_TO_TABLES.keys()))
         ]
 
         for bench_name in bench_names:

--- a/behavior/plans/diff.py
+++ b/behavior/plans/diff.py
@@ -469,7 +469,8 @@ def main(data_dir, output_dir, experiment) -> None:
     for mode in ["train", "eval"]:
         experiment_root: Path = data_dir / mode / experiment
         bench_names: list[str] = [
-            d.name for d in experiment_root.iterdir() if d.is_dir() and d.name in BENCHDB_TO_TABLES
+            d.name for d in experiment_root.iterdir() if d.is_dir()\
+            and d.name.startswith(tuple(BENCHDB_TO_TABLES.keys()))
         ]
 
         for bench_name in bench_names:

--- a/config/behavior/default.yaml
+++ b/config/behavior/default.yaml
@@ -9,6 +9,12 @@ datagen:
   sqlsmith: False           # Currently ignored because it causes dataset naming conflicts.
   log_level: DEBUG
   debug: False
+  param_sweep:
+    scalefactor: [0.01, 0.1]
+    terminals: [1]
+    works.work.rate: [10000]
+    works.work.time: [60]
+    
 
 # Modeling Configuration
 modeling:

--- a/evaluation/utils.py
+++ b/evaluation/utils.py
@@ -51,18 +51,18 @@ def inject_param_xml(file_path, params):
 # recursive calling routine on parameter space.
 # f is a callback function with closure, it should deside
 # what to do with a permutation list of parameters.
-def parameter_sweep(ps_space, f):
-    parameter_sweep_r(ps_space, [], f)
+def parameter_sweep(ps_space, f, closure=dict()):
+    parameter_sweep_r(ps_space, [], f, closure)
 
-def parameter_sweep_r(ps_space, cur_params, f):
+def parameter_sweep_r(ps_space, cur_params, f, closure):
     if len(cur_params) == len(ps_space):
-        f(cur_params)
+        f(cur_params, closure)
         return
     
     name_level, val_list = ps_space[len(cur_params)]
     for val in val_list:
         cur_params.append((name_level, val))
-        parameter_sweep_r(ps_space, cur_params, f)
+        parameter_sweep_r(ps_space, cur_params, f, closure)
         del cur_params[-1]
 
 if __name__ == '__main__':

--- a/evaluation/utils.py
+++ b/evaluation/utils.py
@@ -96,6 +96,10 @@ def parameter_sweep(ps_space, f, closure=None):
         Closure environment passed from caller.
     '''
     assert(len(ps_space) > 0), 'Parameter space should not be empty.\nCheck the configuration file.'
+
+    if closure is None:
+        closure = {}
+
     # Maintain the traverse states. Initial to the first value on level 0.
     cursor_stack = [-1]
     parameters = []

--- a/evaluation/utils.py
+++ b/evaluation/utils.py
@@ -2,82 +2,135 @@ import numpy as np
 import xml.etree.ElementTree as ET
 import yaml
 
-# dist is a map of string->list[];
-# return a list of tuple (list[], list[]),
-# xml namespace & a list of values.
 def param_sweep_space(ps_dist):
+    '''Construct parameter sweep space from configuration.
+    
+    Parameters:
+    ------------
+    ps_dist : Dict[str, List[Any]]
+        Contains parameter name to candidate value lists.
+
+    Returns:
+    ---------
+    ps_space : List[Tuple(List[str], List[Any])]
+        Return parameter sweeping space as a list of tuples of pairs of list.
+        Parse name as name level, handle linear range scales.
+    '''
     ps_space = []
+    assert ps_dist is not None and len(ps_dist) > 0, 'Parameter space should not be empty.\nCheck the configuration file.'
     for name in ps_dist:
         val_list = ps_dist[name]
-        if val_list is None or len(val_list) == 0:
-            raise Exception('parameter space should not be empty.')
+        assert val_list is not None and len(val_list) > 0, 'Parameter space should not be empty.\nCheck the configuration file.'
         
         xml_level = list(name.strip().split('.'))
 
-        # linear scale range
+        # Linear scale range
         if (val_list[0] == '.range'):
-            if len(val_list) not in (3, 4):
-                raise Exception('incorrect argument number for linear scale')
-            if (val_list == 3):
-                val_list = np.arange(val_list[1], val_list[2], 1).tolist()
-            else:
-                val_list = np.arange(val_list[1], val_list[2], val_list[3]).tolist()
+            def convert_range(range_list):
+                '''Convert a list starting with .range to linear range.
+
+                Parameters:
+                ------------
+                range_list : List[Any]
+                The range statement. First should be .range; should be 3 or 4 in length.
+                
+                Returns:
+                -----------
+                values : List[Num]
+                The list of numeric values generated.
+                '''
+                LENGTH_NO_STEP = 3
+                LENGTH_WITH_STEP = 4
+                assert len(range_list) in (LENGTH_NO_STEP, LENGTH_WITH_STEP), 'Incorrect argument number for linear scale.\nCheck the configuration file.'
+                if (len(range_list) == LENGTH_NO_STEP):
+                    start, end, step = range_list[1], range_list[2], 1
+                else:
+                    start, end, step = range_list[1:]
+
+                values = np.arange(start, end, step).tolist()
+                return values
+
+            val_list = convert_range(val_list)
 
         ps_space.append((xml_level, val_list))
 
     return ps_space
 
-# inject list of param to certain xml file, given that file path name.
-# return an xml etree structure.
-def inject_param_xml(file_path, params):
+def inject_param_xml(file_path, parameters):
+    '''Inject and re-write XML file with given parameters.
+
+    Parameters:
+    -----------
+    file_path : str
+        XML file path to inject.
+    parameters : List[Tuple(List[str], Any)]
+        The list of parameter names and values to inject.
+    '''
     conf_etree = ET.parse(file_path)
     root = conf_etree.getroot()
-    for name_level, val in params:
+    for name_level, val in parameters:
         cursor = root
-        # traverse xml name levels.
+        # Traverse XML name levels.
         for key in name_level:
             cursor = cursor.find(key)
             if cursor is None:
                 break
 
-        if cursor is None:
-            print('Warning: fail to inject parameter in conf file,', name_level)
-            continue
-
+        assert cursor is not None, 'Fail to inject parameter in conf file,' + str(name_level) + '\nCheck the format of target XML file.'
         cursor.text = str(val)
 
     conf_etree.write(file_path)
 
-# recursive calling routine on parameter space.
-# f is a callback function with closure, it should deside
-# what to do with a permutation list of parameters.
-def parameter_sweep(ps_space, f, closure=dict()):
+def parameter_sweep(ps_space, f, closure=None):
+    '''Recursive calling routine on parameter space.
+
+    Parameters:
+    ------------
+    ps_space : List[Tuple(List[str], List[Any])]
+        Parameter space to sweep. each element is parameter name level + value list.
+    f : (List[Tuple(List[str], Any)], Dict[str, Any])->Any
+        Callback function to be executed in the sweep, takes parameter combination
+        and closure dict.
+    closure : Dict[str, Any]
+        Closure environment passed from caller.
+    '''
+    def parameter_sweep_r(ps_space, cur_params, f, closure):
+        '''Recursive helper.
+        
+        Parameters:
+        ------------
+        ps_space : List[Tuple(List[str], List[Any])]
+            Parameter space to sweep. each element is parameter name level + value list.
+        cur_params : List[Tuple(List[str], Any)]
+            Current parameter list selected in recursive space.
+        f : (List[Tuple(List[str], Any)], Dict[str, Any])->Any
+            Callback function to be executed in the sweep, takes parameter combination
+            and closure dict.
+        closure : Dict[str, Any]
+            Closure environment passed from caller.
+        '''
+        if len(cur_params) == len(ps_space):
+            f(cur_params, closure)
+            return
+        
+        name_level, val_list = ps_space[len(cur_params)]
+        for val in val_list:
+            cur_params.append((name_level, val))
+            parameter_sweep_r(ps_space, cur_params, f, closure)
+            del cur_params[-1]
+
     parameter_sweep_r(ps_space, [], f, closure)
 
-def parameter_sweep_r(ps_space, cur_params, f, closure):
-    if len(cur_params) == len(ps_space):
-        f(cur_params, closure)
-        return
-    
-    name_level, val_list = ps_space[len(cur_params)]
-    for val in val_list:
-        cur_params.append((name_level, val))
-        parameter_sweep_r(ps_space, cur_params, f, closure)
-        del cur_params[-1]
-
 if __name__ == '__main__':
-    config = yaml.load(open("behavior/default.yaml", "r", encoding="utf-8"), Loader=yaml.FullLoader)
+    # This standalone block of code is only used for tests.
+    config = yaml.load(open("config/behavior/default.yaml", "r", encoding="utf-8"), Loader=yaml.FullLoader)
     ps = param_sweep_space(config['datagen']['param_sweep'])
     print(ps)
 
-    def f(params):
+    def f(params, closure):
         print('_'.join([x[0][-1] + '_' + str(x[1]) for x in params]))
         
-
     parameter_sweep(ps, f)
-
-    import os
-    os.remove('test.xml')
 
 
             

--- a/evaluation/utils.py
+++ b/evaluation/utils.py
@@ -1,0 +1,83 @@
+import numpy as np
+import xml.etree.ElementTree as ET
+import yaml
+
+# dist is a map of string->list[];
+# return a list of tuple (list[], list[]),
+# xml namespace & a list of values.
+def param_sweep_space(ps_dist):
+    ps_space = []
+    for name in ps_dist:
+        val_list = ps_dist[name]
+        if val_list is None or len(val_list) == 0:
+            raise Exception('parameter space should not be empty.')
+        
+        xml_level = list(name.strip().split('.'))
+
+        # linear scale range
+        if (val_list[0] == '.range'):
+            if len(val_list) not in (3, 4):
+                raise Exception('incorrect argument number for linear scale')
+            if (val_list == 3):
+                val_list = np.arange(val_list[1], val_list[2], 1).tolist()
+            else:
+                val_list = np.arange(val_list[1], val_list[2], val_list[3]).tolist()
+
+        ps_space.append((xml_level, val_list))
+
+    return ps_space
+
+# inject list of param to certain xml file, given that file path name.
+# return an xml etree structure.
+def inject_param_xml(file_path, params):
+    conf_etree = ET.parse(file_path)
+    root = conf_etree.getroot()
+    for name_level, val in params:
+        cursor = root
+        # traverse xml name levels.
+        for key in name_level:
+            cursor = cursor.find(key)
+            if cursor is None:
+                break
+
+        if cursor is None:
+            print('Warning: fail to inject parameter in conf file,', name_level)
+            continue
+
+        cursor.text = str(val)
+
+    conf_etree.write(file_path)
+
+# recursive calling routine on parameter space.
+# f is a callback function with closure, it should deside
+# what to do with a permutation list of parameters.
+def parameter_sweep(ps_space, f):
+    parameter_sweep_r(ps_space, [], f)
+
+def parameter_sweep_r(ps_space, cur_params, f):
+    if len(cur_params) == len(ps_space):
+        f(cur_params)
+        return
+    
+    name_level, val_list = ps_space[len(cur_params)]
+    for val in val_list:
+        cur_params.append((name_level, val))
+        parameter_sweep_r(ps_space, cur_params, f)
+        del cur_params[-1]
+
+if __name__ == '__main__':
+    config = yaml.load(open("behavior/default.yaml", "r", encoding="utf-8"), Loader=yaml.FullLoader)
+    ps = param_sweep_space(config['datagen']['param_sweep'])
+    print(ps)
+
+    def f(params):
+        print('_'.join([x[0][-1] + '_' + str(x[1]) for x in params]))
+        
+
+    parameter_sweep(ps, f)
+
+    import os
+    os.remove('test.xml')
+
+
+            


### PR DESCRIPTION
Add support for parameter sweeps in training data generation.

- The parameters to be swept are specified in `config/behavior/default.yaml`.
    - Ranges are supported in the usual (start,stop,step) format, for example: `works.work.rate: [.range, 10000, 15000, 1000]`. 
    - To view the parameters that will be sweeped, execute the test code with `python3 -m evaluation.utils`.
- Add general purpose parameter sweeping code in the `evaluation` module.

Example parameter configuration:
```yaml
  param_sweep:
    scalefactor: [0.01, 0.1]
    terminals: [1]
    works.work.rate: [10000]
    works.work.time: [60]
```

---

The parameter sweep is made as an independent model in `evaluation/utils.py`.
As long as you have configuraiton and a call back function/closure, you can use `param_sweep_space` and `parameter_sweep` to go over the parameter permutations for whatever tasks.