### PR TITLE
Add `branch_name` as an option to `benchbase_clone` (default: main).

### DIFF
--- a/dodos/benchbase.py
+++ b/dodos/benchbase.py
@@ -25,8 +25,8 @@ def task_benchbase_clone():
     BenchBase: clone.
     """
 
-    def repo_clone(repo_url):
-        cmd = f"git clone {repo_url} --branch main --single-branch --depth 1 {BUILD_PATH}"
+    def repo_clone(repo_url, branch_name):
+        cmd = f"git clone {repo_url} --branch {branch_name} --single-branch --depth 1 {BUILD_PATH}"
         return cmd
 
     return {
@@ -47,6 +47,12 @@ def task_benchbase_clone():
                 "long": "repo_url",
                 "help": "The repository to clone from.",
                 "default": "https://github.com/cmu-db/benchbase.git",
+            },
+            {
+                "name": "branch_name",
+                "long": "branch_name",
+                "help": "The name of the branch to checkout.",
+                "default": "main",
             },
         ],
     }


### PR DESCRIPTION
Add `branch_name` as an option to `benchbase_clone` (default: main).

In combination with the existing `repo_url` parameter, this lets us
fully customize the version of BenchBase used in scripts.
For example, `doit benchbase_clone --branch_name="project1"`.

---

Manually verified to work with one of the dependabot branches `dependabot/maven/org.slf4j-slf4j-api-1.7.35`.