### PR TITLE
Fix paths so that microservice artifacts go into their own folder.

### DIFF
--- a/behavior/microservice/app.py
+++ b/behavior/microservice/app.py
@@ -50,7 +50,7 @@ def infer(model_type, ou_type):
 def connect():
     db = getattr(g, "_database", None)
     if db is None:
-        db = g._database = sqlite3.connect("inference.db")
+        db = g._database = sqlite3.connect("./artifacts/behavior/microservice/inference.db")
     return db
 
 

--- a/dodos/behavior.py
+++ b/dodos/behavior.py
@@ -97,12 +97,12 @@ def task_behavior_microservice():
         experiment_name = experiment_list[-1]
 
         server_cmd = local["python3"]["-m", "behavior", "microservice", "--models-path", experiment_name]
-        dest_stdout = "artifacts/behavior/microservice.out"
+        dest_stdout = "artifacts/behavior/microservice/microservice.out"
         ret = server_cmd.run_nohup(stdout=dest_stdout)
         print(f"Behavior models microservice: {dest_stdout} {ret.pid}")
 
     return {
-        "actions": [run_microservice],
+        "actions": ["mkdir -p ./artifacts/behavior/microservice/", run_microservice],
         "verbosity": VERBOSITY_DEFAULT,
     }
 


### PR DESCRIPTION
Moves the following default artifact locations:

- `./artifacts/behavior/microservice.out` -> `./artifacts/behavior/microservice/microservice.out`
- `./inference.db` -> `./artifacts/behavior/microservice/inference.db`

This should have been pushed to #34.