### PR TITLE
Project 1: Additional help for working with NoisePage-Pilot.

### DIFF
--- a/dodo.py
+++ b/dodo.py
@@ -8,3 +8,4 @@ from dodos.ci import *
 from dodos.forecast import *
 from dodos.noisepage import *
 from dodos.pilot import *
+from dodos.project1 import *

--- a/dodos/project1.py
+++ b/dodos/project1.py
@@ -1,0 +1,49 @@
+from plumbum import cmd
+from dodos import VERBOSITY_DEFAULT
+
+DEFAULT_DB="project1db"
+DEFAULT_USER="project1user"
+DEFAULT_PASS="project1pass"
+
+def task_project1_enable_logging():
+    """
+    Project1: enable logging. (will cause a restart)
+    """
+    sql_list = [
+        "ALTER SYSTEM SET log_destination='csvlog'",
+        "ALTER SYSTEM SET logging_collector='on'",
+        "ALTER SYSTEM SET log_statement='all'",
+    ]
+
+    return {
+        "actions": [
+            *[
+                f'PGPASSWORD={DEFAULT_PASS} psql --host=localhost --dbname={DEFAULT_DB} --username={DEFAULT_USER} --command="{sql}"'
+                for sql in sql_list
+            ],
+            lambda: cmd.sudo["systemctl"]["restart", "postgresql"].run_fg(),
+        ],
+        "verbosity": VERBOSITY_DEFAULT,
+    }
+
+
+def task_project1_disable_logging():
+    """
+    Project1: disable logging. (will cause a restart)
+    """
+    sql_list = [
+        "ALTER SYSTEM SET log_destination='stderr'",
+        "ALTER SYSTEM SET logging_collector='off'",
+        "ALTER SYSTEM SET log_statement='none'",
+    ]
+
+    return {
+        "actions": [
+            *[
+                f'PGPASSWORD={DEFAULT_PASS} psql --host=localhost --dbname={DEFAULT_DB} --username={DEFAULT_USER} --command="{sql}"'
+                for sql in sql_list
+            ],
+            lambda: cmd.sudo["systemctl"]["restart", "postgresql"].run_fg(),
+        ],
+        "verbosity": VERBOSITY_DEFAULT,
+    }

--- a/dodos/project1.py
+++ b/dodos/project1.py
@@ -47,3 +47,18 @@ def task_project1_disable_logging():
         ],
         "verbosity": VERBOSITY_DEFAULT,
     }
+
+def task_project1_reset_db():
+    """
+    Project1: drop (if exists) and create project1db.
+    """
+
+    return {
+        "actions": [
+            # Drop the project database if it exists.
+            f"PGPASSWORD={DEFAULT_PASS} dropdb --host=localhost --username={DEFAULT_USER} --if-exists {DEFAULT_DB}",
+            # Create the project database.
+            f"PGPASSWORD={DEFAULT_PASS} createdb --host=localhost --username={DEFAULT_USER} {DEFAULT_DB}",
+        ],
+        "verbosity": VERBOSITY_DEFAULT,
+    }

--- a/dodos/project1.py
+++ b/dodos/project1.py
@@ -1,9 +1,11 @@
 from plumbum import cmd
+
 from dodos import VERBOSITY_DEFAULT
 
-DEFAULT_DB="project1db"
-DEFAULT_USER="project1user"
-DEFAULT_PASS="project1pass"
+DEFAULT_DB = "project1db"
+DEFAULT_USER = "project1user"
+DEFAULT_PASS = "project1pass"
+
 
 def task_project1_enable_logging():
     """
@@ -47,6 +49,7 @@ def task_project1_disable_logging():
         ],
         "verbosity": VERBOSITY_DEFAULT,
     }
+
 
 def task_project1_reset_db():
     """

--- a/project/README.md
+++ b/project/README.md
@@ -1,0 +1,81 @@
+# Quickstart
+
+1. Install PostgreSQL 14.
+2. (Optional but recommended) Tune your PostgreSQL instance with something like `PGTune`.
+3. As the PostgreSQL user,
+   1. `sudo su postgres`
+   2. `psql`
+   3. `create user project1user with superuser encrypted password 'project1pass';`
+4. Create a new GitHub repo that contains one file, `dodo.py`, which contains the following:
+```python
+def task_project1():
+    return {
+        # A list of actions. This can be bash or Python callables.
+        "actions": [
+            'echo "Faking action generation."',
+            'echo "SELECT 1;" > actions.sql',
+            'echo "SELECT 2;" >> actions.sql',
+            'echo \'{"VACUUM": true}\' > config.json',
+        ],
+        # Always rerun this task.
+        "uptodate": [False],
+    }
+```
+5. Add your GitHub repo to `project1.sh` under the `STUDENTS` section, format `git_url,andrew_id`.
+6. Run `./project/project1.sh`.
+
+This sets up the same infrastructure used for grading.  
+At a high-level, this is how grading works:
+
+```python
+def grade():
+    while True: # Up to some timeout T1.
+        exitcode = grade_iteration()
+        if exitcode != 0:
+            break
+
+def grade_iteration():
+    # Dump current DB.
+    # STUDENT CODE: run `doit project1` to generate actions.csv, config.json; up to another timeout T2.
+    # Restore DB from dump.
+    # Apply actions from actions.csv.
+    # VACUUM if requested from config.json.
+    # Run BenchBase to evaluate the current configuration.
+```
+
+## Stuff to know
+
+- All `doit` commands assume they are executed from the project root.
+- You only need to know about these commands:
+    - `doit benchbase_clone`: clone BenchBase.
+    - `doit benchbase_run`: run BenchBase.
+    - `doit project1_disable_logging`: disable logging and restart PostgreSQL.
+    - `doit project1_enable_logging`: enable logging and restart PostgreSQL.
+    - Try running `doit help benchbase_clone`, for example, to see the arguments it supports.
+- We basically use `doit` as a powerful domain-specific language that we invoke from Bash scripts.
+
+For example, this is how you can collect a workload trace for ePinions with a small scalefactor of 1:
+
+```bash
+# Clone Andy's BenchBase.
+doit benchbase_clone --repo_url="https://github.com/apavlo/benchbase.git" --branch_name="main"
+cp ./build/benchbase/config/postgres/15799_starter_config.xml ./config/behavior/benchbase/epinions_config.xml
+
+# Generate the ePinions config file.
+mkdir -p artifacts/project/
+cp ./config/behavior/benchbase/epinions_config.xml ./artifacts/project/epinions_config.xml
+xmlstarlet edit --inplace --update '/parameters/url' --value "jdbc:postgresql://localhost:5432/project1db?preferQueryMode=extended" ./artifacts/project/epinions_config.xml
+xmlstarlet edit --inplace --update '/parameters/username' --value "project1user" ./artifacts/project/epinions_config.xml
+xmlstarlet edit --inplace --update '/parameters/password' --value "project1pass" ./artifacts/project/epinions_config.xml
+xmlstarlet edit --inplace --update '/parameters/scalefactor' --value "1" ./artifacts/project/epinions_config.xml
+
+# Load ePinions.
+doit benchbase_run --benchmark="epinions" --config="./artifacts/project/epinions_config.xml" --args="--create=true --load=true"
+
+# Collect the workload trace of executing ePinions.
+doit project1_enable_logging
+doit benchbase_run --benchmark="epinions" --config="./artifacts/project/epinions_config.xml" --args="--execute=true"
+doit project1_disable_logging
+
+sudo ls -lah /var/lib/postgresql/14/main/log/ | grep csv
+```

--- a/project/README.md
+++ b/project/README.md
@@ -1,12 +1,13 @@
 # Quickstart
 
-1. Install PostgreSQL 14.
-2. (Optional but recommended) Tune your PostgreSQL instance with something like `PGTune`.
-3. As the PostgreSQL user,
+1. Clone this NoisePage-Pilot repo.
+2. Install PostgreSQL 14.
+3. (Optional but recommended) Tune your PostgreSQL instance with something like `PGTune`.
+4. As the PostgreSQL user,
    1. `sudo su postgres`
    2. `psql`
    3. `create user project1user with superuser encrypted password 'project1pass';`
-4. Create a new GitHub repo that contains one file, `dodo.py`, which contains the following:
+5. Create a new GitHub repo that contains one file, `dodo.py`, which contains the following:
 ```python
 def task_project1():
     return {

--- a/project/README.md
+++ b/project/README.md
@@ -80,5 +80,6 @@ doit project1_enable_logging
 doit benchbase_run --benchmark="epinions" --config="./artifacts/project/epinions_config.xml" --args="--execute=true"
 doit project1_disable_logging
 
+# Look at your collected files (and any old traces -- beware!).
 sudo ls -lah /var/lib/postgresql/14/main/log/ | grep csv
 ```

--- a/project/README.md
+++ b/project/README.md
@@ -58,6 +58,8 @@ def grade_iteration():
 For example, this is how you can collect a workload trace for ePinions with a small scalefactor of 1:
 
 ```bash
+doit project1_reset_db
+
 # Clone Andy's BenchBase.
 doit benchbase_clone --repo_url="https://github.com/apavlo/benchbase.git" --branch_name="main"
 cp ./build/benchbase/config/postgres/15799_starter_config.xml ./config/behavior/benchbase/epinions_config.xml

--- a/project/README.md
+++ b/project/README.md
@@ -22,7 +22,7 @@ def task_project1():
         "uptodate": [False],
     }
 ```
-5. Add your GitHub repo to `project1.sh` under the `STUDENTS` section, format `git_url,andrew_id`.
+5. Add your GitHub repo to `./project/project1.sh` under the `STUDENTS` section, format `git_url,andrew_id`.
 6. Run `./project/project1.sh`.
 
 This sets up the same infrastructure used for grading.  

--- a/project/project1.sh
+++ b/project/project1.sh
@@ -5,14 +5,16 @@
 # Define all the students, format is "git_url,andrew_id".
 STUDENTS=(
   'git@github.com:lmwnshn/S22-15799.git,wanshenl'
-  'git@github.com:lmwnshn/S22-15799.git,wanshenl2'
 )
 
 # TODO(Matt): Update benchmark list with workloads.
 BENCHMARKS=(
-  'tpcc'
-  'tatp'
+  'epinions'
+  'indexjungle'
 )
+
+# Set VERBOSITY to 0 for grading, 2 for development.
+VERBOSITY=2
 
 # You should set up a user like this. The script will handle creating the database.
 # postgres=# create user project1user with superuser encrypted password 'project1pass';
@@ -49,7 +51,7 @@ _setup_benchmark() {
   xmlstarlet edit --inplace --update '/parameters/password' --value "${DB_PASS}" ./artifacts/project/${benchmark}_config.xml
 
   # Load the benchmark into the project database.
-  doit --verbosity 0 benchbase_run --benchmark="${benchmark}" --config="./artifacts/project/${benchmark}_config.xml" --args="--create=true --load=true"
+  doit --verbosity ${VERBOSITY} benchbase_run --benchmark="${benchmark}" --config="./artifacts/project/${benchmark}_config.xml" --args="--create=true --load=true"
 }
 
 _dump_database() {
@@ -106,7 +108,7 @@ _grade_iteration() {
   # cd to the original root folder again.
   cd - 1>/dev/null || exit 1
   # Evaluate the performance on the workload.
-  doit --verbosity 0 benchbase_run --benchmark="${benchmark}" --config="./artifacts/project/${benchmark}_config.xml" --args="--execute=true"
+  doit --verbosity ${VERBOSITY} benchbase_run --benchmark="${benchmark}" --config="./artifacts/project/${benchmark}_config.xml" --args="--execute=true"
   # Yoink the result files.
   mkdir -p "${results_folder}"
   mv ./artifacts/benchbase/results/* "${results_folder}"
@@ -197,7 +199,10 @@ main() {
   rm -rf ./artifacts/
   rm -rf ./build/
 
-  doit benchbase_clone --branch_name="project1"
+  # Use Andy's version of BenchBase.
+  doit benchbase_clone --repo_url="https://github.com/apavlo/benchbase.git" --branch_name="main"
+  cp ./build/benchbase/config/postgres/15799_starter_config.xml ./config/behavior/benchbase/epinions_config.xml
+  cp ./build/benchbase/config/postgres/15799_indexjungle_config.xml ./config/behavior/benchbase/indexjungle_config.xml
 
   benchmark_dump_folder="./artifacts/project/dumps"
   # Create the folder for all the benchmark dumps.


### PR DESCRIPTION
This PR adds:

- A `./project/README.md` for people to get started quickly.
- `doit project1_enable_logging`, `doit project1_disable_logging`, `doit project1_reset_db`.
- Easy `VERBOSITY` control for `./project/project1.sh`.
- Example instructions of how to collect a workload trace in this framework using `doit benchbase_run`.