### PR TITLE
Project 1: use simple query protocol by default.

### DIFF
--- a/project/project1.sh
+++ b/project/project1.sh
@@ -46,7 +46,7 @@ _setup_benchmark() {
   # Modify the BenchBase benchmark configuration.
   mkdir -p artifacts/project/
   cp ./config/behavior/benchbase/${benchmark}_config.xml ./artifacts/project/${benchmark}_config.xml
-  xmlstarlet edit --inplace --update '/parameters/url' --value "jdbc:postgresql://localhost:5432/${DB_NAME}?preferQueryMode=extended" ./artifacts/project/${benchmark}_config.xml
+  xmlstarlet edit --inplace --update '/parameters/url' --value "jdbc:postgresql://localhost:5432/${DB_NAME}?preferQueryMode=simple" ./artifacts/project/${benchmark}_config.xml
   xmlstarlet edit --inplace --update '/parameters/username' --value "${DB_USER}" ./artifacts/project/${benchmark}_config.xml
   xmlstarlet edit --inplace --update '/parameters/password' --value "${DB_PASS}" ./artifacts/project/${benchmark}_config.xml
 


### PR DESCRIPTION
BenchBase defaults to simple query protocol.
I made it default to `preferQueryMode=extended` in the project 1 starter code.
This switches it back to explicitly `preferQueryMode=simple`.