### PR TITLE
NoisePage Startup and Datagen Configuration Patches

### DIFF
--- a/behavior/README.md
+++ b/behavior/README.md
@@ -69,8 +69,6 @@ Caveats:
 
 - Various benchmarks yield slightly different OUs for a BenchBase run with the same configuration. Cause unknown.
 - If the BenchBase experiment duration is too short, you may not get data for all OUs.
-- Using pg_stat_statements and auto_explain will affect benchmark statistics and model performance.
-    - These are only intended for debugging.
 - TPC-H support is blocked on the [native loader](https://github.com/cmu-db/benchbase/pull/99) being merged.
 - Epinions is missing results for the Materialize OU in the plan generated for `GetReviewsByUser`.
     - `SELECT * FROM review r, useracct u WHERE u.u_id = r.u_id AND r.u_id=$1 ORDER BY rating LIMIT 10`

--- a/behavior/datagen/gen.py
+++ b/behavior/datagen/gen.py
@@ -452,7 +452,7 @@ class DataGeneratorCLI(cli.Application):
 
         # Setup experiment directory.
         experiment_name = f"experiment-{datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}"
-        modes = ["train", "eval"] if not self.config["debug"] else ["debug"]
+        modes = ["train", "eval"]
 
         # For each training mode, ...
         for mode in modes:

--- a/config/behavior/datagen.yaml
+++ b/config/behavior/datagen.yaml
@@ -6,8 +6,6 @@ datagen:
   log_level: DEBUG
   debug: False
   param_sweep:
-    url: ["jdbc:postgresql://localhost:5432/benchbase?preferQueryMode=extended"]
-    isolation: [TRANSACTION_READ_COMMITTED]
     scalefactor: [0.01, 0.1]
     terminals: [1]
     works.work.rate: [10000]

--- a/config/behavior/datagen.yaml
+++ b/config/behavior/datagen.yaml
@@ -1,0 +1,14 @@
+# DataGeneratorCLI configuration.
+datagen:
+  pg_prewarm: True
+  pg_analyze: True
+  benchmarks: [tpcc]        # Benchmarks include: [auctionmark, epinions, seats, sibench, smallbank, tatp, tpcc, tpch, twitter, voter, wikipedia, ycsb]
+  log_level: DEBUG
+  debug: False
+  param_sweep:
+    url: ["jdbc:postgresql://localhost:5432/benchbase?preferQueryMode=extended"]
+    isolation: [TRANSACTION_READ_COMMITTED]
+    scalefactor: [0.01, 0.1]
+    terminals: [1]
+    works.work.rate: [10000]
+    works.work.time: [60]

--- a/config/behavior/datagen.yaml
+++ b/config/behavior/datagen.yaml
@@ -4,7 +4,6 @@ datagen:
   pg_analyze: True
   benchmarks: [tpcc]        # Benchmarks include: [auctionmark, epinions, seats, sibench, smallbank, tatp, tpcc, tpch, twitter, voter, wikipedia, ycsb]
   log_level: DEBUG
-  debug: False
   param_sweep:
     scalefactor: [0.01, 0.1]
     terminals: [1]

--- a/config/behavior/modeling.yaml
+++ b/config/behavior/modeling.yaml
@@ -1,21 +1,3 @@
-# DataGeneratorCLI configuration.
-datagen:
-  pg_prewarm: True
-  pg_analyze: True
-  pg_stat_statements: False # Intended for debugging only, as it affects benchmark and modeling results.
-  pg_store_plans: False     # Currently not installed.
-  auto_explain: False       # Intended for debugging only, as it affects benchmark and modeling results.
-  benchmarks: [tpcc]        # Benchmarks include: [auctionmark, epinions, seats, sibench, smallbank, tatp, tpcc, tpch, twitter, voter, wikipedia, ycsb]
-  sqlsmith: False           # Currently ignored because it causes dataset naming conflicts.
-  log_level: DEBUG
-  debug: False
-  param_sweep:
-    scalefactor: [0.01, 0.1]
-    terminals: [1]
-    works.work.rate: [10000]
-    works.work.time: [60]
-    
-
 # Modeling Configuration
 modeling:
   train_bench_db: tpcc

--- a/config/postgres/default_postgresql.conf
+++ b/config/postgres/default_postgresql.conf
@@ -5,32 +5,30 @@ listen_addresses = 'localhost'
 port = 5432
 compute_query_id = on
 
-# Extensions
-shared_preload_libraries = 'auto_explain,pg_stat_statements'
-auto_explain.log_min_duration = '-1'
-auto_explain.log_analyze = 'false'
-auto_explain.log_format = 'json'
-auto_explain.log_verbose = 'true'
-pg_stat_statements.max = 10000
-pg_stat_statements.track = all
-pg_stat_statements.save = off
-
-# PGTune suggested these parameters for group's default Intel NUCs
+# PGTune suggested these parameters for (dev4)
+# https://pgtune.leopard.in.ua/
+#   - DB Version: 14
+#   - OS Type: Linux
+#   - DB Type: Mixed Type of Application
+#   - Total Memory: 128 GB
+#   - Number of CPUs: 40
+#   - Number of Connections: 200
+#   - Data Storage: SSD
 max_connections = 200
-shared_buffers = 8GB
-effective_cache_size = 24GB
+shared_buffers = 32GB
+effective_cache_size = 96GB
 maintenance_work_mem = 2GB
 checkpoint_completion_target = 0.9
 wal_buffers = 16MB
 default_statistics_target = 100
 random_page_cost = 1.1
 effective_io_concurrency = 200
-work_mem = 10485kB
+work_mem = 20971kB
 min_wal_size = 1GB
 max_wal_size = 4GB
-max_worker_processes = 8
+max_worker_processes = 40
 max_parallel_workers_per_gather = 4
-max_parallel_workers = 8
+max_parallel_workers = 40
 max_parallel_maintenance_workers = 4
 
 # Logging

--- a/config/postgres/default_postgresql.conf
+++ b/config/postgres/default_postgresql.conf
@@ -30,6 +30,7 @@ max_worker_processes = 40
 max_parallel_workers_per_gather = 4
 max_parallel_workers = 40
 max_parallel_maintenance_workers = 4
+shared_preload_libraries = 'hutch_extension'
 
 # Logging
 log_statement = 'none'			# Options include: none, ddl, mod, all.

--- a/config/postgres/dev4_postgresql.conf
+++ b/config/postgres/dev4_postgresql.conf
@@ -10,30 +10,30 @@ compute_query_id = on
 #   - DB Version: 14
 #   - OS Type: Linux
 #   - DB Type: Mixed Type of Application
-#   - Total Memory: 8 GB
-#   - Number of CPUs: 4
-#   - Number of Connections: N/A
+#   - Total Memory: 128 GB
+#   - Number of CPUs: 40
+#   - Number of Connections: 200
 #   - Data Storage: SSD
-max_connections = 100
-shared_buffers = 2GB
-effective_cache_size = 6GB
-maintenance_work_mem = 512MB
+max_connections = 200
+shared_buffers = 32GB
+effective_cache_size = 96GB
+maintenance_work_mem = 2GB
 checkpoint_completion_target = 0.9
 wal_buffers = 16MB
 default_statistics_target = 100
 random_page_cost = 1.1
 effective_io_concurrency = 200
-work_mem = 5242kB
+work_mem = 20971kB
 min_wal_size = 1GB
 max_wal_size = 4GB
-max_worker_processes = 4
-max_parallel_workers_per_gather = 2
-max_parallel_workers = 4
-max_parallel_maintenance_workers = 2
+max_worker_processes = 40
+max_parallel_workers_per_gather = 4
+max_parallel_workers = 40
+max_parallel_maintenance_workers = 4
 
 # Logging
 log_statement = 'none'			# Options include: none, ddl, mod, all.
-log_destination = 'stderr'		# Valid values are combinations of stderr, csvlog, syslog, and eventlog, depending on platform.  
+log_destination = 'stderr'		# Valid values are combinations of stderr, csvlog, syslog, and eventlog, depending on platform.
                                 # csvlog requires logging_collector to be on.
 logging_collector = on          # Enable capturing of stderr and csvlog into log files.
 log_directory = 'log'           # Directory where log files are written.
@@ -41,7 +41,7 @@ log_filename = 'postgresql.log'
 log_line_prefix = '%m [%p] | QueryID: %Q | '
 log_rotation_size = 1GB         # TODO(Garrison): Try to avoid log rotation (default is 10MB).
 
-# Postgres 14 doesn't support having log_statement_stats 
+# Postgres 14 doesn't support having log_statement_stats
 # enabled while using any of the "per-module" options,
 # e.g., parser, planner, executor.
 log_statement_stats = off

--- a/dodos/behavior.py
+++ b/dodos/behavior.py
@@ -10,8 +10,9 @@ ARTIFACTS_PATH = default_artifacts_path()
 BUILD_PATH = default_build_path()
 
 # Input: various configuration files.
-CONFIG_FILE = Path("config/behavior/default.yaml").absolute()
-POSTGRESQL_CONF = Path("config/behavior/postgres/postgresql.conf").absolute()
+DATAGEN_CONFIG_FILE = Path("config/behavior/datagen.yaml").absolute()
+MODELING_CONFIG_FILE = Path("config/behavior/modeling.yaml").absolute()
+POSTGRESQL_CONF = Path("config/postgres/default_postgresql.conf").absolute()
 
 # Scratch work.
 BUILD_DATAGEN_PATH = BUILD_PATH / "datagen"
@@ -31,7 +32,7 @@ def task_behavior_datagen():
     datagen_args = (
         f"--benchbase-user {dodos.benchbase.DEFAULT_USER} "
         f"--benchbase-pass {dodos.benchbase.DEFAULT_PASS} "
-        f"--config-file {CONFIG_FILE} "
+        f"--config-file {DATAGEN_CONFIG_FILE} "
         f"--dir-benchbase {dodos.benchbase.ARTIFACTS_PATH} "
         f"--dir-benchbase-config {dodos.benchbase.CONFIG_FILES} "
         f"--dir-noisepage-bin {dodos.noisepage.ARTIFACTS_PATH} "
@@ -68,7 +69,7 @@ def task_behavior_train():
     Behavior modeling: train OU models.
     """
     train_args = (
-        f"--config-file {CONFIG_FILE} "
+        f"--config-file {MODELING_CONFIG_FILE} "
         f"--dir-data-train {ARTIFACT_DATA_DIFF / 'diff/train'} "
         f"--dir-data-eval {ARTIFACT_DATA_DIFF / 'diff/eval'} "
         f"--dir-output {ARTIFACT_MODELS} "

--- a/dodos/noisepage.py
+++ b/dodos/noisepage.py
@@ -150,7 +150,7 @@ def task_noisepage_hutch_install():
     return {
         "actions": [
             lambda: os.chdir(BUILD_PATH),
-            # Compile Hutch.
+            # Compile and install Hutch.
             "doit hutch_install",
             lambda: os.chdir(ARTIFACTS_PATH),
             *[

--- a/dodos/noisepage.py
+++ b/dodos/noisepage.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 
 import doit
 from doit.action import CmdAction

--- a/dodos/noisepage.py
+++ b/dodos/noisepage.py
@@ -113,6 +113,7 @@ def task_noisepage_init():
 
     sql_list = [
         f"CREATE ROLE {DEFAULT_USER} WITH LOGIN SUPERUSER ENCRYPTED PASSWORD '{DEFAULT_PASS}'",
+        "LOAD 'hutch_extension'",
     ]
 
     return {

--- a/dodos/noisepage.py
+++ b/dodos/noisepage.py
@@ -140,7 +140,7 @@ def task_noisepage_init():
 
 def task_noisepage_hutch_install():
     """
-    NoisePage: install hutch to support EXPLAIN (format tscout)
+    NoisePage: install hutch extension to support EXPLAIN (format tscout).
     """
     sql_list = [
         # Note that this will overwrite any existing settings of shared_preload_libraries.


### PR DESCRIPTION
This diff patches several configuration aspects of how we start NoisePage and the datagen module:
- `noisepage_build` now also builds `hutch`
- `noisepage_init` now takes a path to a config file to load. By default this path is `config/postgres/default_postgresql.conf` which is also the same postgresql configuration file that is used by datagen. A separate configuration file is also provided for dev4.
- Split the configuration for training the models and generating the data into separate files
- Light purge of (mostly unused) aspects of `behavior/datagen/gen.py` 