### PR TITLE
Fix OpenSpiel forecast parsing code.

### DIFF
--- a/action/selection/open_spiel/database.cc
+++ b/action/selection/open_spiel/database.cc
@@ -384,6 +384,9 @@ Forecast::Forecast(const std::string &forecast_path) {
     // Current format: "query","count". It looks horrible because CSV quotes " with "".
     size_t split_index = line.rfind("\",\"");
     std::string query = line.substr(1, split_index - 1);
+    // We have to replace the double-quotes though, otherwise we can hit length limits.
+    std::regex unescape_double_quotes("\"\"");
+    query = std::regex_replace(query, unescape_double_quotes, "\"");
     long long num_times = std::stoll(line.substr(split_index + 3, line.length() - (split_index + 3) - 1));
     workload_.emplace_back(query, num_times);
   }

--- a/action/selection/open_spiel/database.cc
+++ b/action/selection/open_spiel/database.cc
@@ -380,19 +380,11 @@ Forecast::Forecast(const std::string &forecast_path) {
   std::string line;
   long long num_queries_total = 0;
   while (std::getline(forecast_csv, line)) {
-    std::string query;
-    long long num_times;
     // TODO(WAN): Fragile, but we control the output format + we may replace this code with SQL.
-    std::string token;
-    std::istringstream ss(line);
-    std::getline(ss, token, '"');
-    std::getline(ss, token, '"');
-    query = token;
-    std::getline(ss, token, '"');
-    std::getline(ss, token, '"');
-    num_times = std::stoll(token);
-    num_queries_total += num_times;
-
+    // Current format: "query","count". It looks horrible because CSV quotes " with "".
+    size_t split_index = line.rfind("\",\"");
+    std::string query = line.substr(1, split_index - 1);
+    long long num_times = std::stoll(line.substr(split_index + 3, line.length() - (split_index + 3) - 1));
     workload_.emplace_back(query, num_times);
   }
   std::cerr << "\tRead " << workload_.size() << " distinct queries, total " << num_queries_total << "." << std::endl;


### PR DESCRIPTION
Fix OpenSpiel forecast parsing code.

This replaces a fragile CSV hack with a different fragile CSV hack.
Because CSV quotes `"` as `""`, the old code failed on queries containing double-quotes,
e.g., `"This right ""here"" causes issues.","123"` as a sample forecast entry.

Instead, we'll look for `","` and do some old-fashioned string splitting.
We still have to replace `""` with `"` to avoid hitting length limits.