### PR TITLE
Fix Preprocessor's substitute_params by reversing substitution order.

### DIFF
--- a/forecast/preprocessor.py
+++ b/forecast/preprocessor.py
@@ -126,7 +126,8 @@ class Preprocessor:
         assert type(query_template) == str
         query = query_template
         keys = [f"${i}" for i in range(1, len(params) + 1)]
-        for k, v in zip(keys, params):
+        for k, v in reversed(list(zip(keys, params))):
+            # The reversing is crucial! Note that $1 is a prefix of $10.
             query = query.replace(k, v)
         return query
 


### PR DESCRIPTION
Fix Preprocessor's `substitute_params` by reversing substitution order.

This is critical for correctness. Consider this example:

- Query: `SELECT $10 from foo;`
- Parameters: `{$1: "banana", ..., $10: 1}`.
- Substituting left to right, `SELECT "banana"0 from foo;`.
- Substituting right to left, `SELECT 1 from foo;`.