### PR TITLE
Project 1: add `project1_setup` invocation, make a copy of results.

### DIFF
--- a/project/project1.sh
+++ b/project/project1.sh
@@ -104,6 +104,7 @@ _grade_iteration() {
   actions_file="./actions.sql"
   config_file="./config.json"
   dump_folder="./${benchmark}_dump_tmp"
+  local_results_folder="./${submission_path}/grading/iteration_${iteration}/"
 
   echo "Grading benchmark ${benchmark} workload ${workload_csv} iteration ${iteration}: ${submission_path}"
   set -e
@@ -138,6 +139,8 @@ _grade_iteration() {
 
   # Yoink the result files.
   mkdir -p "${results_folder}"
+  mkdir -p "${local_results_folder}"
+  cp ./artifacts/benchbase/results/* "${local_results_folder}"
   mv ./artifacts/benchbase/results/* "${results_folder}"
   # Yoink the student stuff too because why not.
   cp "./${submission_path}/${actions_file}" "${results_folder}"
@@ -173,10 +176,16 @@ _grade() {
   setup_timed_out=$?
   cd -
 
+  # If the student setup timed out, there's nothing else we can do.
   if [ "${setup_timed_out}" = "124" ]; then
     echo "Timed out during setup: ${submission_path}"
     return
   fi
+
+  # Otherwise, copy the bootstrap results into their folder and get ready to grade.
+  # TODO(WAN): Fragile path.
+  mkdir -p "${submission_path}/grading/baseline/"
+  cp -r ${evaluations_folder}/${benchmark}/baseline/* "${submission_path}/grading/baseline/"
 
   # Unfortunately, timeout doesn't work on special Bash constructs.
   # We export the function and wrap everything in a subshell.


### PR DESCRIPTION
This PR adds some student requests. In no particular order,

Invoke `project1_setup` before any grading iterations.
All student submissions must now define `project1_setup`.
If a student submission times out during setup, no further grading is done.

Make a local copy of the results in `./submission_path/grading/`.
Specifically, the baseline results are copied to `./grading/baseline/`,
and each iteration n's results are copied to `./grading/iteration_n/`.

